### PR TITLE
Enhanced suburb search with Nominatim

### DIFF
--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -36,6 +36,9 @@
 		$aPlace['lat'] = $aPointDetails['lat'];
 		$aPlace['lon'] = $aPointDetails['lon'];
 		$aPlace['display_name'] = $aPointDetails['name'];
+		
+		//add shortname for further use
+		$aPlace['short_name'] = $aPointDetails['placename'];
 
 		$aPlace['class'] = $aPointDetails['class'];
 		$aPlace['type'] = $aPointDetails['type'];

--- a/lib/template/suburb-html.php
+++ b/lib/template/suburb-html.php
@@ -1,0 +1,40 @@
+<?php
+header("content-type: text/html; charset=UTF-8");
+?>
+<html>
+  <head>
+    <title>OpenStreetMap Nominatim: Suburbs</title>
+  </head>
+
+<?php
+
+if (sizeof($aParentOfLines)) {
+    $aGroupedAddressLines = array();
+    foreach ($aParentOfLines as $aAddressLine) {
+        if (!isset($aGroupedAddressLines[$aAddressLine['type']]))
+            $aGroupedAddressLines[$aAddressLine['type']] = array();
+        $aGroupedAddressLines[$aAddressLine['type']][] = $aAddressLine;
+    }
+    foreach ($aGroupedAddressLines as $sGroupHeading => $aParentOfLines) {
+        $sGroupHeading = ucwords($sGroupHeading);
+        echo "<h3>$sGroupHeading</h3>";
+        foreach ($aParentOfLines as $aAddressLine) {
+            echo '<div class="line">';
+            echo '<span class="name">' . (trim($aAddressLine['localname']) ? $aAddressLine['localname'] : '<span class="noname">No Name</span>') . '</span>';
+            echo ', <span class="distance">~' . (round($aAddressLine['distance'] * 69, 1)) . '&nbsp;miles</span>';
+            echo ', <span class="lat">lat=' . $aAddressLine['lat'] . '</span>';
+            echo ', <span class="lon">lon=' . $aAddressLine['lon'] . '</span>';
+            echo ', <span class="osm_id">osm_id=' . $aAddressLine['osm_id'] . '</span>';
+            echo ', <span class="place_id">place_id=' . $aAddressLine['place_id'] . '</span>';
+            echo '</div>';
+        }
+    }
+    echo '</div>';
+} else {
+    echo 'No suburbs.';
+}
+
+?>
+
+  </body>
+</html>

--- a/lib/template/suburb-json.php
+++ b/lib/template/suburb-json.php
@@ -7,7 +7,8 @@ foreach ($aParentOfLines as $aAddressLine) {
         'osm_id' => $aAddressLine['osm_id'],
         'display_name' => trim($aAddressLine['localname']) ? $aAddressLine['localname'] : 'No Name',
         'lat' => $aAddressLine['lat'],
-        'lon' => $aAddressLine['lon']
+        'lon' => $aAddressLine['lon'],
+        'short_name' => $aPointDetails['localname']
     );
     
     $aFilteredPlaces[] = $aPlace;

--- a/lib/template/suburb-json.php
+++ b/lib/template/suburb-json.php
@@ -5,7 +5,8 @@ $aFilteredPlaces = array();
 foreach ($aParentOfLines as $aAddressLine) {
     $aPlace = array(
         'osm_id' => $aAddressLine['osm_id'],
-        'display_name' => trim($aAddressLine['localname']) ? $aAddressLine['localname'] : 'No Name',
+        'place_id'=>$aAddressLine['place_id'],
+				'display_name' => trim($aAddressLine['localname']) ? $aAddressLine['localname'] : 'No Name',
         'lat' => $aAddressLine['lat'],
         'lon' => $aAddressLine['lon'],
         'short_name' => $aPointDetails['localname']

--- a/lib/template/suburb-json.php
+++ b/lib/template/suburb-json.php
@@ -1,0 +1,17 @@
+<?php
+
+$aFilteredPlaces = array();
+
+foreach ($aParentOfLines as $aAddressLine) {
+    $aPlace = array(
+        'osm_id' => $aAddressLine['osm_id'],
+        'display_name' => trim($aAddressLine['localname']) ? $aAddressLine['localname'] : 'No Name',
+        'lat' => $aAddressLine['lat'],
+        'lon' => $aAddressLine['lon']
+    );
+    
+    $aFilteredPlaces[] = $aPlace;
+}
+
+
+javascript_renderData($aFilteredPlaces);

--- a/website/suburb.php
+++ b/website/suburb.php
@@ -1,0 +1,90 @@
+<?php
+require_once(dirname(dirname(__FILE__)).'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+
+$sOutputFormat = 'json';
+
+// Format for output
+if (isset($_GET['format']) && ($_GET['format'] == 'html' || $_GET['format'] == 'json')) {
+    $sOutputFormat = $_GET['format'];
+}
+
+
+ini_set('memory_limit', '200M');
+
+$oDB =& getDB();
+
+if (isset($_GET['osmtype']) && isset($_GET['osmid']) && (int) $_GET['osmid'] && ($_GET['osmtype'] == 'N' || $_GET['osmtype'] == 'W' || $_GET['osmtype'] == 'R')) {
+    $_GET['place_id'] = $oDB->getOne("select place_id from placex where osm_type = '" . $_GET['osmtype'] . "' and osm_id = " . (int) $_GET['osmid'] . " order by type = 'postcode' asc");
+}
+
+if (!isset($_GET['place_id'])) {
+    echo "Please select a place id";
+    exit;
+}
+
+$iPlaceID = (int) $_GET['place_id'];
+
+$iParentPlaceID = $oDB->getOne('select parent_place_id from location_property_tiger where place_id = ' . $iPlaceID);
+if ($iParentPlaceID)
+    $iPlaceID = $iParentPlaceID;
+$iParentPlaceID = $oDB->getOne('select parent_place_id from location_property_aux where place_id = ' . $iPlaceID);
+if ($iParentPlaceID)
+    $iPlaceID = $iParentPlaceID;
+
+$aLangPrefOrder        = getPreferredLanguages();
+$sLanguagePrefArraySQL = "ARRAY[" . join(',', array_map("getDBQuoted", $aLangPrefOrder)) . "]";
+
+$hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
+
+// Make sure the point we are reporting on is fully indexed
+//$sSQL = "UPDATE placex set indexed = true where indexed = false and place_id = $iPlaceID";
+//$oDB->query($sSQL);
+
+
+// All places this is an imediate parent of
+//
+// Searching for suburbs
+// First step: search for place:suburb and for boundary:administrative
+
+$sSQL = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, st_distance(geometry, placegeometry) as distance, ";
+$sSQL .= "ST_X(ST_Centroid(geometry)) as lon, ST_Y(ST_Centroid(geometry)) as lat,";
+$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
+$sSQL .= " from placex, (select geometry as placegeometry from placex where place_id = $iPlaceID) as x";
+$sSQL .= " where parent_place_id = $iPlaceID and ((class = 'place' and type = 'suburb') or (class = 'boundary' and type = 'administrative'))";
+$sSQL .= " order by distance";
+#$sSQL .= " order by distance,rank_address asc,rank_search asc,get_name_by_language(name,$sLanguagePrefArraySQL),housenumber";
+
+$aParentOfLines = $oDB->getAll($sSQL);
+
+// if there are no search results for place:suburb or boundary:administrative
+// Second step: search for place:village
+
+if (!sizeof($aParentOfLines)) {
+    $sSQL = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, st_distance(geometry, placegeometry) as distance, ";
+    $sSQL .= "ST_X(ST_Centroid(geometry)) as lon, ST_Y(ST_Centroid(geometry)) as lat,";
+    $sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
+    $sSQL .= " from placex, (select geometry as placegeometry from placex where place_id = $iPlaceID) as x";
+    $sSQL .= " where parent_place_id = $iPlaceID and (class = 'place' and type = 'village')";
+    $sSQL .= " order by distance";
+    
+    $aParentOfLines = $oDB->getAll($sSQL);
+    
+}
+
+
+
+$aPlaceSearchNameKeywords    = false;
+$aPlaceSearchAddressKeywords = false;
+if (isset($_GET['keywords']) && $_GET['keywords']) {
+    $sSQL                        = "select * from search_name where place_id = $iPlaceID";
+    $aPlaceSearchName            = $oDB->getRow($sSQL);
+    $sSQL                        = "select * from word where word_id in (" . substr($aPlaceSearchName['name_vector'], 1, -1) . ")";
+    $aPlaceSearchNameKeywords    = $oDB->getAll($sSQL);
+    $sSQL                        = "select * from word where word_id in (" . substr($aPlaceSearchName['nameaddress_vector'], 1, -1) . ")";
+    $aPlaceSearchAddressKeywords = $oDB->getAll($sSQL);
+}
+
+logEnd($oDB, $hLog, 1);
+
+include(CONST_BasePath.'/lib/template/suburb-'.$sOutputFormat.'.php');


### PR DESCRIPTION
Hello,

we are a company from Karlsruhe (Germany) developing a web service for truck routing. For geocoding we use our own instance of Nominatim. Since the results searching for suburbs of a city with Nominatim's special phrases were not sufficient for us, we added some functionality. Now we get the suburbs (including the suburbs that are of type administrative) of a city by parsing Nominatim's detail page of this city. For this reason we added suburb.php (modified details.php) and two templates so that we get the results as json or html. 
Maybe someone else can need this functionality too.

Commit of Aug 23, 2012:
Added two templates (html, json) for displaying results of suburb
search. Used details.php as pattern to search for suburbs
(boundary:administrative, place:suburb, place:village), modified it,
result is suburb.php
