### PR TITLE
added option to ignore nonsearch terms in geocoding requests

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -16,6 +16,7 @@
 		protected $aExcludePlaceIDs = array();
 		protected $bDeDupe = true;
 		protected $bReverseInPlan = false;
+		protected $bIgnoreNonSearchTerms = CONST_Search_IgnoreNonSearchTerms;
 
 		protected $iLimit = 20;
 		protected $iFinalLimit = 10;
@@ -101,6 +102,11 @@
 		function setDeDupe($bDeDupe = true)
 		{
 			$this->bDeDupe = (bool)$bDeDupe;
+		}
+		
+		function setIgnoreNonSearchTerms($b = true)
+		{
+			$this->bIgnoreNonSearchTerms = (bool)$b;
 		}
 
 		function setLimit($iLimit = 10)
@@ -818,7 +824,7 @@
 													}
 													else
 													{
-														$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+														if (!$this->bIgnoreNonSearchTerms) $aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 														if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 													}
 												}
@@ -830,7 +836,7 @@
 													if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
 													if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
 														$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-													else
+													elseif (!$this->bIgnoreNonSearchTerms)
 														$aSearch['aNameNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 													$aSearch['iNamePhrase'] = $iPhrase;
 													if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -71,6 +71,7 @@
 
 	@define('CONST_Search_TryDroppedAddressTerms', false);
 	@define('CONST_Search_NameOnlySearchFrequencyThreshold', false);
+	@define('CONST_Search_IgnoreNonSearchTerms', false);                // default: false. if true, frequently indexed search terms are ignored rather than filtered out. This greatly help geocoding requests without a road type (ex: 'street' not specified in '500 rivard street') as well as Canadian geocoding requests.
 
 	// Set to zero to disable polygon output
 	@define('CONST_PolygonOutput_MaximumTypes', 1);

--- a/website/search.php
+++ b/website/search.php
@@ -30,6 +30,7 @@
 		if (isset($aParams['addressdetails'])) $oGeocode->setIncludeAddressDetails((bool)$aParams['addressdetails']);
 		if (isset($aParams['bounded'])) $oGeocode->setBounded((bool)$aParams['bounded']);
 		if (isset($aParams['dedupe'])) $oGeocode->setDedupe((bool)$aParams['dedupe']);
+		if (isset($aParams['ignoreNonSearchTerms'])) $oGeocode->setIgnoreNonSearchTerms((bool)$aParams['ignoreNonSearchTerms']);
 
 		if (isset($aParams['limit'])) $oGeocode->setLimit((int)$aParams['limit']);
 		if (isset($aParams['offset'])) $oGeocode->setOffset((int)$aParams['offset']);


### PR DESCRIPTION
The option is not enabled by default.
Allows frequently indexed search terms to be ignored rather than filtered out. This greatly help geocoding requests without a road type (ex: 'street' not specified in '500 rivard street') as well as Canadian geocoding requests.
