### PR TITLE
Added feature that can be used to to restrict results to belong to city specified in input address

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -330,7 +330,7 @@
 			$this->loadStructuredAddressElement($sPostalCode, 'postalcode' , 5, 11, array(5, 11));
 			$this->loadStructuredAddressElement($sCountry, 'country', 4, 4, false);
 
-			if (sizeof($this->aStructuredQuery) > 0) 
+			if (sizeof($this->aStructuredQuery) > 0)
 			{
 				$this->sQuery = join(', ', $this->aStructuredQuery);
 				if ($this->iMaxAddressRank < 30)
@@ -467,7 +467,7 @@
 			  addressimportance: cumulated importance of address elements
 			  extra_place: type of place (for admin boundaries, if there is a place tag)
 			  aBoundingBox: bounding Box
-			  label: short description of the object class/type (English only) 
+			  label: short description of the object class/type (English only)
 			  name: full name (currently the same as langaddress)
 			  foundorder: secondary ordering for places with same importance
 		*/
@@ -544,7 +544,7 @@
 			// Do we have anything that looks like a lat/lon pair?
 			if ( $aLooksLike = looksLikeLatLonPair($sQuery) ){
 				$this->setNearPoint(array($aLooksLike['lat'], $aLooksLike['lon']));
-				$sQuery = $aLooksLike['query'];			
+				$sQuery = $aLooksLike['query'];
 			}
 
 			$aSearchResults = array();

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -5,9 +5,9 @@
 	foreach($aSearchResults as $iResNum => $aPointDetails)
 	{
 		$aPlace = array(
-				'place_id'=>$aPointDetails['place_id'],
-				'licence'=>"Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
-			);
+			'place_id'=>$aPointDetails['place_id'],
+			'licence'=>"Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+		);
 
 		$sOSMType = ($aPointDetails['osm_type'] == 'N'?'node':($aPointDetails['osm_type'] == 'W'?'way':($aPointDetails['osm_type'] == 'R'?'relation':'')));
 		if ($sOSMType)
@@ -16,8 +16,8 @@
 			$aPlace['osm_id'] = $aPointDetails['osm_id'];
 		}
 
-                if (isset($aPointDetails['aBoundingBox']))
-                {
+		if (isset($aPointDetails['aBoundingBox']))
+		{
 			$aPlace['boundingbox'] = array(
 				$aPointDetails['aBoundingBox'][0],
 				$aPointDetails['aBoundingBox'][1],
@@ -28,7 +28,7 @@
 			{
 				$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 			}
-                }
+		}
 
 		if (isset($aPointDetails['zoom']))
 		{
@@ -52,22 +52,22 @@
 		if (isset($aPointDetails['address']))
 		{
 			$aPlace['address'] = $aPointDetails['address'];
-                }
+		}
 
-                if (isset($aPointDetails['asgeojson']))
-                {
-                        $aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-                }
+		if (isset($aPointDetails['asgeojson']))
+		{
+			$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
+		}
 
-                if (isset($aPointDetails['assvg']))
-                {
-                        $aPlace['svg'] = $aPointDetails['assvg'];
-                }
+		if (isset($aPointDetails['assvg']))
+		{
+			$aPlace['svg'] = $aPointDetails['assvg'];
+		}
 
-                if (isset($aPointDetails['astext']))
-                {
-                        $aPlace['geotext'] = $aPointDetails['astext'];
-                }
+		if (isset($aPointDetails['astext']))
+		{
+			$aPlace['geotext'] = $aPointDetails['astext'];
+		}
 
 		if (isset($aPointDetails['askml']))
 		{

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -92,6 +92,11 @@
 	@define('CONST_Search_TryDroppedAddressTerms', false);
 	@define('CONST_Search_NameOnlySearchFrequencyThreshold', false);
 
+	// This disallows returning results that belongs to different city,
+	// even if such match were found
+	// NOTE: this only works with structured query, as that makes recognization of city much, much easier
+	@define('CONST_Search_RestrictResultsToCity', false);
+
 	// Set to zero to disable polygon output
 	@define('CONST_PolygonOutput_MaximumTypes', 1);
 

--- a/website/search.php
+++ b/website/search.php
@@ -85,22 +85,22 @@
 		include(CONST_BasePath.'/lib/template/search-batch-json.php');
 		exit;
 	} else {
-        if (!(isset($_GET['q']) && $_GET['q']) && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
-        {
-            $sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
+		if (!(isset($_GET['q']) && $_GET['q']) && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
+		{
+			$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
 
-            // reverse order of '/' separated string
-            $aPhrases = explode('/', $sQuery);
-            $aPhrases = array_reverse($aPhrases);
-            $sQuery = join(', ',$aPhrases);
-            $oGeocode->setQuery($sQuery);
-        }
-        else
-        {
-            $oGeocode->setQueryFromParams($_GET);
-        }
+			// reverse order of '/' separated string
+			$aPhrases = explode('/', $sQuery);
+			$aPhrases = array_reverse($aPhrases);
+			$sQuery = join(', ',$aPhrases);
+			$oGeocode->setQuery($sQuery);
+		}
+		else
+		{
+			$oGeocode->setQueryFromParams($_GET);
+		}
 
-    }
+	}
 
 	$hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
 


### PR DESCRIPTION
I was getting results from different city, specifically because "Majavakatu 9, Vantaa" does not actually exist in Vantaa, but in Helsinki, there is Majavakatu 9, so it uses it as the street name wholly matches to it. So I added an optional check that will reject a match belonging to different city. It seems to fall back matching against only a street name further on street, so it actually will return the correct address from Vantaa with this code.

Strange debugging note: for some reason, without Wikipedia data, it will return the address in Vantaa anyway. I didn’t really investigate why that’s so as that token parser is fairly annoying to debug. 
