### PR TITLE
Added support for matching details in search response

### DIFF
--- a/lib/lib.php
+++ b/lib/lib.php
@@ -821,6 +821,75 @@
 	}
 
 
+	function getMatchingDetails(&$oDB, $aTokens, $iPlaceID, $bRaw = false)
+	{
+		$aMatching = array();
+		if ($aTokens)
+		{
+			$sMatchArray = "";
+			foreach($aTokens as $sToken)
+			{
+				if ($sMatchArray) $sMatchArray .= ",";
+				$sMatchArray .= getDBQuoted($sToken);
+				$sMatchArray .= ",".getDBQuoted($sToken." %");
+				$sMatchArray .= ",".getDBQuoted("% ".$sToken." %");
+				$sMatchArray .= ",".getDBQuoted("% ".$sToken);
+			}
+
+			$sSQL = "select * from (select place_id,osm_id,osm_type,class,type,admin_level,rank_address,isaddress,(each(name)).* from get_addressdata($iPlaceID)) as matchingnames";
+			if (!$bRaw) {
+				$sSQL .= " WHERE (isaddress OR type = 'country_code') AND";
+			} else {
+				$sSQL .= " WHERE";
+			}
+			$sSQL .= " lower(value) like ANY(ARRAY[".$sMatchArray."])";
+			$sSQL .= " order by rank_address desc,isaddress desc";
+
+			$aMatchingLines = $oDB->getAll($sSQL);
+			if (PEAR::IsError($aMatchingLines))
+			{
+				var_dump($aMatchingLines);
+				exit;
+			}
+			if ($bRaw) return $aMatchingLines;
+
+			$aMatching = array();
+			$aFallback = array();
+			$aClassType = getClassTypes();
+			foreach($aMatchingLines as $aLine)
+			{
+				$bFallback = false;
+				$aTypeLabel = false;
+
+				if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
+				elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
+				elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
+				{
+					$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
+					$bFallback = true;
+				}
+				else
+				{
+					$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
+					$bFallback = true;
+				}
+				if ($aTypeLabel && (isset($aLine['key']) && $aLine['key'] && isset($aLine['value']) && $aLine['value']))
+				{
+					$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
+					$sTypeLabel = str_replace(' ','_',$sTypeLabel);
+					if (!isset($aMatching[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
+					{
+						$aMatching[$sTypeLabel.':'.$aLine['key']] = $aLine['value'];
+					}
+					$aFallback[$sTypeLabel] = $bFallback;
+				}
+			}
+		}
+
+		return $aMatching;
+	}
+
+
 	function geocodeReverse($fLat, $fLon, $iZoom=18)
 	{
 		$oDB =& getDB();

--- a/lib/template/search-batch-json.php
+++ b/lib/template/search-batch-json.php
@@ -21,8 +21,8 @@
 				$aPlace['osm_id'] = $aPointDetails['osm_id'];
 			}
 
-        	        if (isset($aPointDetails['aBoundingBox']))
-                	{
+			if (isset($aPointDetails['aBoundingBox']))
+			{
 				$aPlace['boundingbox'] = array(
 					$aPointDetails['aBoundingBox'][0],
 					$aPointDetails['aBoundingBox'][1],
@@ -33,7 +33,7 @@
 				{
 					$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 				}
-	                }
+			}
 
 			if (isset($aPointDetails['zoom']))
 			{
@@ -58,27 +58,32 @@
 			if (isset($aPointDetails['address']) && sizeof($aPointDetails['address'])>0)
 			{
 				$aPlace['address'] = $aPointDetails['address'];
-        	        }
+			}
 
-	                if (isset($aPointDetails['asgeojson']))
-        	        {
+			if (isset($aPointDetails['matching']) && sizeof($aPointDetails['matching']) > 0)
+			{
+				$aPlace['matching'] = $aPointDetails['matching'];
+			}
+
+			if (isset($aPointDetails['asgeojson']))
+			{
 				$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-        	        }
+			}
 
-	                if (isset($aPointDetails['assvg']))
-        	        {
+			if (isset($aPointDetails['assvg']))
+			{
 				$aPlace['svg'] = $aPointDetails['assvg'];
-	                }
+			}
 
-	                if (isset($aPointDetails['astext']))
-        	        {
-                	        $aPlace['geotext'] = $aPointDetails['astext'];
-	                }
+			if (isset($aPointDetails['astext']))
+			{
+				$aPlace['geotext'] = $aPointDetails['astext'];
+			}
 
-        	        if (isset($aPointDetails['askml']))
-                	{
-                        	$aPlace['geokml'] = $aPointDetails['askml'];
-	                }
+			if (isset($aPointDetails['askml']))
+			{
+				$aPlace['geokml'] = $aPointDetails['askml'];
+			}
 
 			$aFilteredPlaces[] = $aPlace;
 		}

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -16,8 +16,8 @@
 			$aPlace['osm_id'] = $aPointDetails['osm_id'];
 		}
 
-                if (isset($aPointDetails['aBoundingBox']))
-                {
+		if (isset($aPointDetails['aBoundingBox']))
+		{
 			$aPlace['boundingbox'] = array(
 				$aPointDetails['aBoundingBox'][0],
 				$aPointDetails['aBoundingBox'][1],
@@ -28,7 +28,7 @@
 			{
 				$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 			}
-                }
+		}
 
 		if (isset($aPointDetails['zoom']))
 		{
@@ -52,22 +52,28 @@
 		if (isset($aPointDetails['address']))
 		{
 			$aPlace['address'] = $aPointDetails['address'];
-                }
+		}
 
-                if (isset($aPointDetails['asgeojson']))
-                {
-                        $aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-                }
+		if (isset($aPointDetails['matching']))
+		{
+			$aPlace['matching'] = $aPointDetails['matching'];
+		}
 
-                if (isset($aPointDetails['assvg']))
-                {
-                        $aPlace['svg'] = $aPointDetails['assvg'];
-                }
 
-                if (isset($aPointDetails['astext']))
-                {
-                        $aPlace['geotext'] = $aPointDetails['astext'];
-                }
+		if (isset($aPointDetails['asgeojson']))
+		{
+			$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
+		}
+
+		if (isset($aPointDetails['assvg']))
+		{
+			$aPlace['svg'] = $aPointDetails['assvg'];
+		}
+
+		if (isset($aPointDetails['astext']))
+		{
+			$aPlace['geotext'] = $aPointDetails['astext'];
+		}
 
 		if (isset($aPointDetails['askml']))
 		{

--- a/lib/template/search-jsonv2.php
+++ b/lib/template/search-jsonv2.php
@@ -14,8 +14,8 @@
 			$aPlace['osm_id'] = $aPointDetails['osm_id'];
 		}
 
-                if (isset($aPointDetails['aBoundingBox']))
-                {
+		if (isset($aPointDetails['aBoundingBox']))
+		{
 			$aPlace['boundingbox'] = array(
 				$aPointDetails['aBoundingBox'][0],
 				$aPointDetails['aBoundingBox'][1],
@@ -26,7 +26,7 @@
 			{
 				$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 			}
-                }
+		}
 
 		if (isset($aPointDetails['zoom']))
 		{
@@ -51,27 +51,33 @@
 		if (isset($aPointDetails['address']) && sizeof($aPointDetails['address'])>0)
 		{
 			$aPlace['address'] = $aPointDetails['address'];
-                }
+		}
 
-                if (isset($aPointDetails['asgeojson']))
-                {
+		if (isset($aPointDetails['matching']) && sizeof($aPointDetails['matching'])>0)
+		{
+			$aPlace['matching'] = $aPointDetails['matching'];
+		}
+
+
+		if (isset($aPointDetails['asgeojson']))
+		{
 			$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-                }
+		}
 
-                if (isset($aPointDetails['assvg']))
-                {
+		if (isset($aPointDetails['assvg']))
+		{
 			$aPlace['svg'] = $aPointDetails['assvg'];
-                }
+		}
 
-                if (isset($aPointDetails['astext']))
-                {
-                        $aPlace['geotext'] = $aPointDetails['astext'];
-                }
+		if (isset($aPointDetails['astext']))
+		{
+			$aPlace['geotext'] = $aPointDetails['astext'];
+		}
 
-                if (isset($aPointDetails['askml']))
-                {
-                        $aPlace['geokml'] = $aPointDetails['askml'];
-                }
+		if (isset($aPointDetails['askml']))
+		{
+			$aPlace['geokml'] = $aPointDetails['askml'];
+		}
 
 		$aFilteredPlaces[] = $aPlace;
 	}

--- a/lib/template/search-xml.php
+++ b/lib/template/search-xml.php
@@ -87,7 +87,7 @@
 			echo " icon='".htmlspecialchars($aResult['icon'], ENT_QUOTES)."'";
 		}
 
-		if (isset($aResult['address']) || isset($aResult['askml']))
+		if (isset($aResult['address'])  || isset($aResult['matching']) || isset($aResult['askml']))
 		{
 			echo ">";
 		}
@@ -111,7 +111,21 @@
 			}
 		}
 
-		if (isset($aResult['address']) || isset($aResult['askml']))
+		if (isset($aResult['matching']))
+		{
+			echo "\n<matching>";
+			foreach($aResult['matching'] as $sKey => $sValue)
+			{
+				$sKey = str_replace(' ','_',$sKey);
+				$sKey = str_replace(':','-',$sKey);
+				echo "<$sKey>";
+				echo htmlspecialchars($sValue);
+				echo "</$sKey>";
+			}
+			echo "</matching>";
+		}
+
+		if (isset($aResult['address']) || isset($aResult['matching']) || isset($aResult['askml']))
 		{
 			echo "</place>";
 		}


### PR DESCRIPTION
Adds the option to get values matching the search input in the response. This is needed for external scoring calculation of the response.
Example: A user searches for the Swedish name "Eiffeltornet" and get "Eiffel tower" as response since using a client in English. To be able to evaluate the quality of the returned hit we would like to know it has the Swedish name "Eiffeltornet" too.

The implementation and usage follows the pattern of address details. Type is added to the beginning of each key to indicate the origin.
Request: ...&q=eiffeltornet&matchingdetails=1
Response: ..."matching":{"attraction:name:sv":"Eiffeltornet"}...
