### PR TITLE
Merge street number hits with streets in result

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1786,6 +1786,8 @@
 
 				$aResult['importance'] = $aResult['importance'] + ($iCountWords*0.1); // 0.1 is a completely arbitrary number but something in the range 0.1 to 0.5 would seem right
 
+				if ($searchedHousenumber != -1 && preg_match("/(^|,)\s*".preg_quote($searchedHousenumber, '/')."\s*(,|$)/", $sAddress)) $aResult['importance'] += 0.11;
+
 				$aResult['name'] = $aResult['langaddress'];
 				// secondary ordering (for results with same importance (the smaller the better):
 				//   - approximate importance of address parts


### PR DESCRIPTION
This change mixes street number hits with streets where the sought number isn't found. A remaining issue exists for streets with multiple segments, where both a street number hit and the remaining segments where the number isn't found are included in the response.

Fixes #422 
