### PR TITLE
special treatment for US state Michigan

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -827,6 +827,7 @@
 				$sQuery = preg_replace('/(^|,)\s*il\s*(,|$)/','\1illinois\2', $sQuery);
 				$sQuery = preg_replace('/(^|,)\s*al\s*(,|$)/','\1alabama\2', $sQuery);
 				$sQuery = preg_replace('/(^|,)\s*la\s*(,|$)/','\1louisiana\2', $sQuery);
+				$sQuery = preg_replace('/(^|,)\s*mi\s*(,|$)/','\1michigan\2', $sQuery);
 			}
 
 			// View Box SQL


### PR DESCRIPTION
When searching for 'mi' Nominatim returns the country 'United States' as first results, 'Michigan, United States' as second
http://nominatim.openstreetmap.org/search.php?q=mi

That's because the 'United States' http://www.openstreetmap.org/relation/148838 has the tag `alt_name:vi=Hoa Kì;Mỹ;Mĩ`, `short_name:vi=Mỹ`

On https://vi.wikipedia.org/wiki/Hoa_K%E1%BB%B3 I can see 'Hoa Kì' and 'Mỹ', but not 'Mĩ' so I'm not certain how common 'Mĩ' really is.

The `search.feature` already has a test case for `Scenario: Expansion of Illinois` so I wasn't sure if another test is necessary here.
