### PR TITLE
travis-ci.org changed from Postgres 9.2 to 9.1, while libpg is 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language:
   - 'python'
 sudo: required
 dist: trusty
+addons:
+  postgresql: "9.5"
 before_install:
   - git submodule update --init --recursive
 install:

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -6,7 +6,8 @@
 # user 'travis'
 # $TRAVIS_BUILD_DIR is /home/travis/build/twain47/Nominatim/, for more see
 #   https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-# Postgres 9.2 installed and started. role 'travis' already superuser
+# Postgres 9.5, PostGIS 2.2 installed and started. role 'travis' already superuser.
+# https://docs.travis-ci.com/user/database-setup/#PostgreSQL
 # Python 2.7.10, pip 7.1.2
 
 # Travis has a 4 MB, 10000 line output limit, so where possible we supress
@@ -19,7 +20,7 @@ sudo apt-get update -qq
 sudo apt-get install -y -qq libboost-dev libboost-system-dev \
                         libboost-filesystem-dev libexpat1-dev zlib1g-dev libxml2-dev\
                         libbz2-dev libpq-dev libgeos-c1 libgeos++-dev libproj-dev \
-                        postgresql-server-dev-9.3 postgresql-9.3-postgis-2.1 postgresql-contrib-9.3 \
+                        postgresql-server-dev-9.5 \
                         apache2 php5 php5-pgsql php-pear php-db
 
 sudo apt-get install -y -qq python-Levenshtein python-shapely \
@@ -28,7 +29,8 @@ sudo apt-get install -y -qq python-Levenshtein python-shapely \
 
 sudo -H pip install --quiet 'setuptools>=23.0.0' lettuce==0.2.18 'six>=1.9' haversine
 
-sudo service postgresql restart
+#sudo service postgresql restart
+sudo service postgresql start 9.5
 sudo -u postgres createuser -S www-data
 
 # Make sure that system servers can read from the home directory:


### PR DESCRIPTION
A couple of weeks ago Travis-ci.org made it possible to specify which Postgres version one wants in the `.travis.yml` file. Before the default was an already started 9.2.
https://github.com/travis-ci/travis-ci/issues/4264
https://docs.travis-ci.com/user/database-setup/#PostgreSQL

Now the default became 9.1 but 9.2-9.5 were also present. So a `service postgresql stop` shows

```
        * Stopping PostgreSQL 9.1 database server
        * Stopping PostgreSQL 9.2 database server
        * Stopping PostgreSQL 9.3 database server
        * Stopping PostgreSQL 9.4 database server
        * Stopping PostgreSQL 9.5 database server   
```

Since that change when specifying 9.3, the version we used in the past, it caused trouble.
- cmake found `libpq.so` version 9.5.4

```
-- Found the following Boost libraries:
--   system
--   filesystem
-- Found PostgreSQL: /usr/lib/x86_64-linux-gnu/libpq.so (found version "9.5.4") 
```
- while `setup.php` found version 9.1

```
Create DB
Setup DB
Postgres version found: 9.1
CREATE EXTENSION
```
- and eventually the build broke `/module/nominatim.so: undefined symbol: palloc`

I ran 10 travis-ci builds to set versions and deinstall/purge/remove the other packages. The only working combination was to use version 9.5. Not ideal of course.

Successful build: https://travis-ci.org/mtmail/Nominatim/builds/157511690
