### PR TITLE
Fix for Russel Way in TIGER 2016 data (v2)

### DIFF
--- a/docs/Import_and_update.md
+++ b/docs/Import_and_update.md
@@ -85,11 +85,11 @@ instance by following these steps:
        * Ubuntu: `sudo apt-get install python-gdal`
        * CentOS: `sudo yum install gdal-python`
 
-  2. Get the TIGER 2015 data. You will need the EDGES files
+  2. Get the TIGER 2016 data. You will need the EDGES files
      (3,234 zip files, 11GB total). Choose one of the two sources:
 
-         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2015/EDGES/
-         wget -r ftp://mirror1.shellbot.com/census/geo/tiger/TIGER2015/EDGES/
+         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2016/EDGES/
+         wget -r ftp://mirror1.shellbot.com/census/geo/tiger/TIGER2016/EDGES/
 
      The first one is the original source, the second a considerably faster
      mirror.
@@ -97,6 +97,7 @@ instance by following these steps:
   3. Convert the data into SQL statements (stored in data/tiger): 
 
          ./utils/imports.php --parse-tiger <tiger edge data directory>
+         ./utils/imports.php --patch-tiger
 
   4. Import the data into your Nominatim database: 
 

--- a/utils/imports.php
+++ b/utils/imports.php
@@ -12,7 +12,8 @@ $aCMDOptions
     array('quiet', 'q', 0, 1, 0, 0, 'bool', 'Quiet output'),
     array('verbose', 'v', 0, 1, 0, 0, 'bool', 'Verbose output'),
 
-    array('parse-tiger', '', 0, 1, 1, 1, 'realpath', 'Convert tiger edge files to nominatim sql import - datafiles from 2011 or later (source: edges directory of tiger data)'),
+    array('parse-tiger', '', 0, 1, 1, 1, 'realpath', 'Convert Tiger edge files to nominatim sql import - datafiles from 2011 or later (source: edges directory of tiger data)'),
+    array('patch-tiger', '', 0, 1, 0, 0, 'bool', 'Fix converted Tiger data files')
    );
 getCmdOpt($_SERVER['argv'], $aCMDOptions, $aCMDResult, true, true);
 
@@ -20,7 +21,7 @@ getCmdOpt($_SERVER['argv'], $aCMDOptions, $aCMDResult, true, true);
 if (isset($aCMDResult['parse-tiger'])) {
     if (!file_exists(CONST_Tiger_Data_Path)) mkdir(CONST_Tiger_Data_Path);
 
-    $sTempDir = tempnam('/tmp', 'tiger');
+    $sTempDir = tempnam(sys_get_temp_dir(), 'tiger');
     unlink($sTempDir);
     mkdir($sTempDir);
 
@@ -45,8 +46,11 @@ if (isset($aCMDResult['parse-tiger'])) {
             }
         }
         // Cleanup
-        foreach (glob($sTempDir.'/*') as $sTmpFile) {
-            unlink($sTmpFile);
-        }
+        array_map('unlink', glob($sTempDir.'/*'));
     }
+}
+
+if (isset($aCMDResult['patch-tiger'])) {
+    $sPatchSQL = CONST_InstallPath.'/utils/tigerPatchSQL.sh ' . CONST_Tiger_Data_Path;
+    exec($sPatchSQL);
 }

--- a/utils/tigerPatchSQL.sh
+++ b/utils/tigerPatchSQL.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# A typo in the Tiger 2016 data. Russel Way in the county Belnap should have
+# the zip code 03089.
+
+BELKNAP_FILE="$1/33001.sql"
+
+if [[ ! -e $BELKNAP_FILE ]]; then
+    echo "$BELKNAP_FILE not found"
+    exit 1
+fi
+
+# change file inline
+sed -i -- "s/'Russel Way', 'Belknap, NH', '83809'/'Russel Way', 'Belknap, NH', '03809'/" $BELKNAP_FILE
+
+# doublecheck
+if [[ `grep 83809 $BELKNAP_FILE` -ne '0' ]]; then
+    echo "Patching $BELKNAP_FILE failed"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR replaces https://github.com/twain47/Nominatim/pull/594.

The patch logic is no longer hidden inside the import script. Since it's a separate step and separate script it can be extended should we find more errors. Hopefully in 6 months the Tiger 2017 data has it fixed anyway.


