### PR TITLE
cmake: add a more explicit hint when osm2pgsql is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ add_definitions(-DNOMINATIM_VERSION="${NOMINATIM_VERSION}")
 
 set(BUILD_TESTS off CACHE BOOL "Build test suite" FORCE)
 set(WITH_LUA off CACHE BOOL "Build with lua support" FORCE)
+
+if (NOT EXISTS "${CMAKE_SOURCE_DIR}/osm2pgsql/CMakeLists.txt")
+    message(FATAL_ERROR "The osm2pgsql directory is empty.\
+    Did you forget to check out Nominatim recursively?\
+    \nTry updating submodules with: git submodules update --init")
+endif()
 add_subdirectory(osm2pgsql)
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Fixes #642.