### PR TITLE
Add all intersecting boundaries to address list for roads

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -1679,7 +1679,12 @@ BEGIN
   -- added ourself as address already
   address_havelevel[NEW.rank_address] := true;
   -- RAISE WARNING '  getNearFeatures(%,''%'',%,''%'')',NEW.partition, place_centroid, search_maxrank, isin_tokens;
-  FOR location IN SELECT * from getNearFeatures(NEW.partition, place_centroid, search_maxrank, isin_tokens) LOOP
+  FOR location IN
+    SELECT * from getNearFeatures(NEW.partition,
+                                  CASE WHEN NEW.rank_search >= 26 THEN NEW.geometry
+                                  ELSE place_centroid END,
+                                  search_maxrank, isin_tokens)
+  LOOP
 
 --RAISE WARNING '  AREA: %',location;
 

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -1,4 +1,4 @@
-create or replace function getNearFeatures(in_partition INTEGER, point GEOMETRY, maxrank INTEGER, isin_tokens INT[]) RETURNS setof nearfeaturecentr AS $$
+create or replace function getNearFeatures(in_partition INTEGER, feature GEOMETRY, maxrank INTEGER, isin_tokens INT[]) RETURNS setof nearfeaturecentr AS $$
 DECLARE
   r nearfeaturecentr%rowtype;
 BEGIN
@@ -6,14 +6,14 @@ BEGIN
 -- start
   IF in_partition = -partition- THEN
     FOR r IN 
-      SELECT place_id, keywords, rank_address, rank_search, min(ST_Distance(point, centroid)) as distance, isguess, centroid FROM (
-        SELECT * FROM location_area_large_-partition- WHERE ST_Contains(geometry, point) and rank_search < maxrank
+      SELECT place_id, keywords, rank_address, rank_search, min(ST_Distance(feature, centroid)) as distance, isguess, centroid FROM (
+        SELECT * FROM location_area_large_-partition- WHERE ST_Intersects(geometry, feature) and rank_search < maxrank
         UNION ALL
-        SELECT * FROM location_area_country WHERE ST_Contains(geometry, point) and rank_search < maxrank
+        SELECT * FROM location_area_country WHERE ST_Intersects(geometry, feature) and rank_search < maxrank
       ) as location_area
       GROUP BY place_id, keywords, rank_address, rank_search, isguess, centroid
       ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
-        ST_Distance(point, centroid) * 
+        ST_Distance(feature, centroid) *
           CASE 
                WHEN rank_address = 16 AND rank_search = 15 THEN 0.2 -- capital city
                WHEN rank_address = 16 AND rank_search = 16 THEN 0.25 -- city

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -1,0 +1,22 @@
+@DB
+Feature: Address computation
+    Tests for filling of place_addressline
+
+    # github #121
+    Scenario: Roads crossing boundaries should contain both states
+        Given the grid
+            | 1 |   |   | 2 |   | 3 |
+            |   | 7 |   | 8 |   |   |
+            | 4 |   |   | 5 |   | 6 |
+        And the named places
+            | osm | class   | type | geometry |
+            | W1  | highway | road | 7, 8     |
+        And the named places
+            | osm | class    | type           | admin | geometry      |
+            | W10 | boundary | administrative | 5     | (1, 2, 5, 4, 1) |
+            | W11 | boundary | administrative | 5     | (2, 3, 6, 5, 2) |
+        When importing
+        Then place_addressline contains
+            | object | address | cached_rank_address |
+            | W1     | W10     | 10                  |
+            | W1     | W11     | 10                  |


### PR DESCRIPTION
When roads cross boundaries, both administrative entities should
be added to the address list, so that both entities can be used
for searching. Also allows in a second step to better sort out
addresses of POIs on such roads.

Fixes #121.