### PR TITLE
On /search.php the map-position box disappeared behind the map tiles

### DIFF
--- a/website/css/search.css
+++ b/website/css/search.css
@@ -65,7 +65,7 @@ form label {
   color: #333;
   font-size: 11px;
   background-color: rgba(255, 255, 255, 0.7);
-  z-index: 100;
+  z-index: 500;
 }
 
 #map-position-close {


### PR DESCRIPTION
After the new leaflet 1.0 CSS got applied the map-position box disappeared behind the map tiles after clicking the 'show map bounds' button.

P.S. what do you think about adding a link to http://tools.geofabrik.de/osmi/?view=addresses&lon=-1.98369&lat=43.32181&zoom=18 for debugging as well?