### PR TITLE
Move address information into hstore column

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -423,7 +423,7 @@ class Geocode
         $sSQL .= "    rank_address,";
         $sSQL .= "    min(place_id) AS place_id, ";
         $sSQL .= "    min(parent_place_id) AS parent_place_id, ";
-        $sSQL .= "    calculated_country_code AS country_code, ";
+        $sSQL .= "    country_code, ";
         $sSQL .= "    get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress,";
         $sSQL .= "    get_name_by_language(name, $sLanguagePrefArraySQL) AS placename,";
         $sSQL .= "    get_name_by_language(name, ARRAY['ref']) AS ref,";
@@ -466,7 +466,7 @@ class Geocode
         $sSQL .= "     admin_level, ";
         $sSQL .= "     rank_search, ";
         $sSQL .= "     rank_address, ";
-        $sSQL .= "     calculated_country_code, ";
+        $sSQL .= "     country_code, ";
         $sSQL .= "     importance, ";
         if (!$this->bDeDupe) $sSQL .= "place_id,";
         $sSQL .= "     langaddress, ";
@@ -551,7 +551,7 @@ class Geocode
             $sSQL .= "  30 AS rank_address, ";
             $sSQL .= "  min(place_id) as place_id, ";
             $sSQL .= "  min(parent_place_id) AS parent_place_id, ";
-            $sSQL .= "  calculated_country_code AS country_code, ";
+            $sSQL .= "  country_code, ";
             $sSQL .= "  get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) AS langaddress, ";
             $sSQL .= "  null AS placename, ";
             $sSQL .= "  null AS ref, ";
@@ -576,7 +576,7 @@ class Geocode
             $sSQL .= "     SELECT ";
             $sSQL .= "         osm_id, ";
             $sSQL .= "         place_id, ";
-            $sSQL .= "         calculated_country_code, ";
+            $sSQL .= "         country_code, ";
             $sSQL .= "         CASE ";             // interpolate the housenumbers here
             $sSQL .= "           WHEN startnumber != endnumber ";
             $sSQL .= "           THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
@@ -595,7 +595,7 @@ class Geocode
             $sSQL .= "    osm_id, ";
             $sSQL .= "    place_id, ";
             $sSQL .= "    housenumber_for_place, ";
-            $sSQL .= "    calculated_country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
+            $sSQL .= "    country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
             if (!$this->bDeDupe) $sSQL .= ", place_id ";
 
             if (CONST_Use_Aux_Location_data) {
@@ -1239,8 +1239,8 @@ class Geocode
                         if ($aSearch['sCountryCode'] && !$aSearch['sClass'] && !$aSearch['sHouseNumber']) {
                             // Just looking for a country by code - look it up
                             if (4 >= $this->iMinAddressRank && 4 <= $this->iMaxAddressRank) {
-                                $sSQL = "SELECT place_id FROM placex WHERE calculated_country_code='".$aSearch['sCountryCode']."' AND rank_search = 4";
-                                if ($sCountryCodesSQL) $sSQL .= " AND calculated_country_code in ($sCountryCodesSQL)";
+                                $sSQL = "SELECT place_id FROM placex WHERE country_code='".$aSearch['sCountryCode']."' AND rank_search = 4";
+                                if ($sCountryCodesSQL) $sSQL .= " AND country_code in ($sCountryCodesSQL)";
                                 if ($bBoundingBoxSearch)
                                     $sSQL .= " AND _st_intersects($this->sViewboxSmallSQL, geometry)";
                                 $sSQL .= " ORDER BY st_area(geometry) DESC LIMIT 1";
@@ -1258,7 +1258,7 @@ class Geocode
                                 $sSQL = "SELECT place_id FROM place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
                                 if ($sCountryCodesSQL) $sSQL .= " JOIN placex USING (place_id)";
                                 $sSQL .= " WHERE st_contains($this->sViewboxSmallSQL, ct.centroid)";
-                                if ($sCountryCodesSQL) $sSQL .= " AND calculated_country_code in ($sCountryCodesSQL)";
+                                if ($sCountryCodesSQL) $sSQL .= " AND country_code in ($sCountryCodesSQL)";
                                 if (sizeof($this->aExcludePlaceIDs)) {
                                     $sSQL .= " AND place_id not in (".join(',', $this->aExcludePlaceIDs).")";
                                 }
@@ -1275,7 +1275,7 @@ class Geocode
                                     $sSQL = "SELECT place_id FROM place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
                                     if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
                                     $sSQL .= " WHERE ST_Contains($this->sViewboxLargeSQL, ct.centroid)";
-                                    if ($sCountryCodesSQL) $sSQL .= " AND calculated_country_code in ($sCountryCodesSQL)";
+                                    if ($sCountryCodesSQL) $sSQL .= " AND country_code in ($sCountryCodesSQL)";
                                     if ($this->sViewboxCentreSQL) $sSQL .= " ORDER BY ST_Distance($this->sViewboxCentreSQL, ct.centroid) ASC";
                                     $sSQL .= " LIMIT $this->iLimit";
                                     if (CONST_Debug) var_dump($sSQL);
@@ -1288,7 +1288,7 @@ class Geocode
                                 $sSQL .= "  AND type='".$aSearch['sType']."'";
                                 $sSQL .= "  AND ST_Contains($this->sViewboxSmallSQL, geometry) ";
                                 $sSQL .= "  AND linked_place_id is null";
-                                if ($sCountryCodesSQL) $sSQL .= " AND calculated_country_code in ($sCountryCodesSQL)";
+                                if ($sCountryCodesSQL) $sSQL .= " AND country_code in ($sCountryCodesSQL)";
                                 if ($this->sViewboxCentreSQL)   $sSQL .= " ORDER BY ST_Distance($this->sViewboxCentreSQL, centroid) ASC";
                                 $sSQL .= " LIMIT $this->iLimit";
                                 if (CONST_Debug) var_dump($sSQL);
@@ -1534,7 +1534,7 @@ class Geocode
                                 $sSQL .= "   AND class='".$aSearch['sClass']."' ";
                                 $sSQL .= "   AND type='".$aSearch['sType']."'";
                                 $sSQL .= "   AND linked_place_id is null";
-                                if ($sCountryCodesSQL) $sSQL .= " AND calculated_country_code in ($sCountryCodesSQL)";
+                                if ($sCountryCodesSQL) $sSQL .= " AND country_code in ($sCountryCodesSQL)";
                                 $sSQL .= " ORDER BY rank_search ASC ";
                                 $sSQL .= " LIMIT $this->iLimit";
                                 if (CONST_Debug) var_dump($sSQL);
@@ -1604,7 +1604,7 @@ class Geocode
                                         if (sizeof($this->aExcludePlaceIDs)) {
                                             $sSQL .= " and l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
                                         }
-                                        if ($sCountryCodesSQL) $sSQL .= " and lp.calculated_country_code in ($sCountryCodesSQL)";
+                                        if ($sCountryCodesSQL) $sSQL .= " and lp.country_code in ($sCountryCodesSQL)";
                                         if ($sOrderBySQL) $sSQL .= "order by ".$sOrderBySQL." asc";
                                         if ($this->iOffset) $sSQL .= " offset $this->iOffset";
                                         $sSQL .= " limit $this->iLimit";
@@ -1631,7 +1631,7 @@ class Geocode
                                         if (sizeof($this->aExcludePlaceIDs)) {
                                             $sSQL .= " AND l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
                                         }
-                                        if ($sCountryCodesSQL) $sSQL .= " AND l.calculated_country_code in ($sCountryCodesSQL)";
+                                        if ($sCountryCodesSQL) $sSQL .= " AND l.country_code in ($sCountryCodesSQL)";
                                         if ($sOrderBy) $sSQL .= "ORDER BY ".$OrderBysSQL." ASC";
                                         if ($this->iOffset) $sSQL .= " OFFSET $this->iOffset";
                                         $sSQL .= " limit $this->iLimit";

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -103,7 +103,7 @@ class PlaceLookup
         $bIsInterpolation = $sType == 'interpolation';
 
         if ($bIsTiger) {
-            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, postcode,";
+            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, postcode,";
             $sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
             $sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as country_code, ";
             $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
@@ -119,7 +119,7 @@ class PlaceLookup
             $sSQL .= " END as housenumber";
             $sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
         } elseif ($bIsInterpolation) {
-            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, postcode,";
+            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, postcode,";
             $sSQL .= " country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
             $sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, country_code, ";
             $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
@@ -139,7 +139,7 @@ class PlaceLookup
             // and not interpolated
         } else {
             $sSQL = "select placex.place_id, partition, osm_type, osm_id, class,";
-            $sSQL .= " type, admin_level, housenumber, street, postcode, country_code,";
+            $sSQL .= " type, admin_level, housenumber, postcode, country_code,";
             $sSQL .= " parent_place_id, linked_place_id, rank_address, rank_search, ";
             $sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, country_code, ";
             $sSQL .= " get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -103,9 +103,9 @@ class PlaceLookup
         $bIsInterpolation = $sType == 'interpolation';
 
         if ($bIsTiger) {
-            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
+            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, postcode,";
             $sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
-            $sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
+            $sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as country_code, ";
             $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
             $sSQL .= " null as placename,";
             $sSQL .= " null as ref,";
@@ -119,9 +119,9 @@ class PlaceLookup
             $sSQL .= " END as housenumber";
             $sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
         } elseif ($bIsInterpolation) {
-            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
-            $sSQL .= " calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
-            $sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code, ";
+            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, postcode,";
+            $sSQL .= " country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
+            $sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, country_code, ";
             $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
             $sSQL .= " null as placename,";
             $sSQL .= " null as ref,";
@@ -139,9 +139,9 @@ class PlaceLookup
             // and not interpolated
         } else {
             $sSQL = "select placex.place_id, partition, osm_type, osm_id, class,";
-            $sSQL .= " type, admin_level, housenumber, street, isin, postcode, country_code,";
+            $sSQL .= " type, admin_level, housenumber, street, postcode, country_code,";
             $sSQL .= " parent_place_id, linked_place_id, rank_address, rank_search, ";
-            $sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
+            $sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, country_code, ";
             $sSQL .= " get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
             $sSQL .= " get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
             $sSQL .= " get_name_by_language(name, ARRAY['ref']) as ref,";

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -118,7 +118,7 @@ class ReverseGeocode
                 $iMaxRank = 26;
             }
 
-            $sSQL = 'select place_id,parent_place_id,rank_search,calculated_country_code';
+            $sSQL = 'select place_id,parent_place_id,rank_search,country_code';
             $sSQL .= ' FROM placex';
             $sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
             $sSQL .= ' and rank_search != 28 and rank_search >= '.$iMaxRank;
@@ -135,7 +135,7 @@ class ReverseGeocode
             );
             $iPlaceID = $aPlace['place_id'];
             $iParentPlaceID = $aPlace['parent_place_id'];
-            $bIsInUnitedStates = ($aPlace['calculated_country_code'] == 'us');
+            $bIsInUnitedStates = ($aPlace['country_code'] == 'us');
         }
 
         // If a house was found make sure there isn't an interpolation line

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -1183,7 +1183,7 @@ BEGIN
         i := getorcreate_housenumber_id(make_standard_name(NEW.address->'conscriptionnumber'));
         IF NEW.address ? 'streetnumber' THEN
             i := getorcreate_housenumber_id(make_standard_name(NEW.address->'streetnumber'));
-            NEW.housenumber := NEW.address->'conscriptionnumber' || '/' || NEW.address->'streetnumber';
+            NEW.housenumber := (NEW.address->'conscriptionnumber') || '/' || (NEW.address->'streetnumber');
         ELSE
             NEW.housenumber := NEW.address->'conscriptionnumber';
         END IF;

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -1001,24 +1001,24 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  NEW.interpolationtype = NEW.address->'interpolation';
-
-  IF NEW.address is not NULL THEN
-      IF NEW.address ? 'street' THEN
-          NEW.street = NEW.address->'street';
-      END IF;
-
-      IF NEW.address ? 'place' THEN
-          NEW.addr_place = NEW.address->'place';
-      END IF;
-
-      IF NEW.address ? 'postcode' THEN
-          NEW.addr_place = NEW.address->'postcode';
-      END IF;
-  END IF;
-
   -- if the line was newly inserted, split the line as necessary
   IF OLD.indexed_status = 1 THEN
+      NEW.interpolationtype = NEW.address->'interpolation';
+
+      IF NEW.address is not NULL THEN
+          IF NEW.address ? 'street' THEN
+              NEW.street = NEW.address->'street';
+          END IF;
+
+          IF NEW.address ? 'place' THEN
+              NEW.addr_place = NEW.address->'place';
+          END IF;
+
+          IF NEW.address ? 'postcode' THEN
+              NEW.addr_place = NEW.address->'postcode';
+          END IF;
+      END IF;
+
       select nodes from planet_osm_ways where id = NEW.osm_id INTO waynodes;
 
       IF array_upper(waynodes, 1) IS NULL THEN
@@ -1222,7 +1222,7 @@ BEGIN
       END IF;
 
       IF NEW.address ? 'postcode' THEN
-        NEW.addr_place = NEW.address->'postcode';
+        NEW.postcode = NEW.address->'postcode';
       END IF;
   END IF;
 
@@ -2146,13 +2146,13 @@ BEGIN
 
 
       IF NEW.class in ('place','boundary') AND NEW.type in ('postcode','postal_code') THEN
-          IF NEW.postcode IS NULL THEN
+          IF NEW.address is NULL OR NOT NEW.address ? 'postcode' THEN
               -- postcode was deleted, no longer retain in placex
               DELETE FROM placex where place_id = existingplacex.place_id;
               RETURN NULL;
           END IF;
 
-          NEW.name := hstore('ref', NEW.postcode);
+          NEW.name := hstore('ref', NEW.address->'postcode');
       END IF;
 
       update placex set 

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -144,8 +144,6 @@ CREATE TABLE placex (
   wikipedia TEXT, -- calculated wikipedia article name (language:title)
   geometry_sector INTEGER,
   country_code varchar(2),
-  street TEXT,
-  addr_place TEXT,
   housenumber TEXT,
   postcode TEXT
   ) {ts:search-data};

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -95,8 +95,6 @@ CREATE TABLE location_property_osmline (
     endnumber INTEGER,
     interpolationtype TEXT,
     address HSTORE,
-    street TEXT,
-    addr_place TEXT,
     postcode TEXT,
     country_code VARCHAR(2),
     geometry_sector INTEGER,

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -94,10 +94,11 @@ CREATE TABLE location_property_osmline (
     startnumber INTEGER,
     endnumber INTEGER,
     interpolationtype TEXT,
+    address HSTORE,
     street TEXT,
     addr_place TEXT,
     postcode TEXT,
-    calculated_country_code VARCHAR(2),
+    country_code VARCHAR(2),
     geometry_sector INTEGER,
     indexed_status INTEGER,
     indexed_date TIMESTAMP){ts:search-data};
@@ -144,7 +145,11 @@ CREATE TABLE placex (
   indexed_date TIMESTAMP,
   wikipedia TEXT, -- calculated wikipedia article name (language:title)
   geometry_sector INTEGER,
-  calculated_country_code varchar(2)
+  country_code varchar(2),
+  street TEXT,
+  addr_place TEXT,
+  housenumber TEXT,
+  postcode TEXT
   ) {ts:search-data};
 SELECT AddGeometryColumn('placex', 'centroid', 4326, 'GEOMETRY', 2);
 CREATE UNIQUE INDEX idx_place_id ON placex USING BTREE (place_id) {ts:search-index};

--- a/test/bdd/db/import/interpolation.feature
+++ b/test/bdd/db/import/interpolation.feature
@@ -7,6 +7,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 2       | 1 1 |
           | N2  | place | house  | 6       | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001 |
         And the ways
           | id | nodes |
@@ -21,6 +23,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 2       | 1 1 |
           | N2  | place | house  | 6       | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1.001, 1 1 |
         And the ways
           | id | nodes |
@@ -35,6 +39,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 1       | 1 1 |
           | N2  | place | house  | 11      | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | odd     | 1 1, 1 1.001 |
         And the ways
           | id | nodes |
@@ -49,6 +55,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 1       | 1 1 |
           | N2  | place | house  | 3       | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | all     | 1 1, 1 1.001 |
         And the ways
           | id | nodes |
@@ -63,6 +71,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 2       | 1 1 |
           | N2  | place | house  | 10      | 1.001 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001, 1.001 1.001 |
         And the ways
           | id | nodes |
@@ -77,6 +87,8 @@ Feature: Import of address interpolations
           | osm | class | type   | housenr | geometry |
           | N1  | place | house  | 2       | 1 1 |
           | N2  | place | house  | 10      | 1.001 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001, 1.001 1.001 |
         And the ways
           | id | nodes |
@@ -92,6 +104,8 @@ Feature: Import of address interpolations
           | N1  | place | house  | 2       | 1 1 |
           | N2  | place | house  | 14      | 1.001 1.001 |
           | N3  | place | house  | 10      | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001, 1.001 1.001 |
         And the ways
           | id | nodes |
@@ -109,6 +123,8 @@ Feature: Import of address interpolations
           | N2  | place | house | 14      | 1.001 1.001 |
           | N3  | place | house | 10      | 1 1.001 |
           | N4  | place | house | 18      | 1.001 1.002 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001, 1.001 1.001, 1.001 1.002 |
         And the ways
           | id | nodes |
@@ -126,6 +142,8 @@ Feature: Import of address interpolations
           | N1  | place | house | 2       | 1 1 |
           | N2  | place | house | 14      | 1.001 1.001 |
           | N3  | place | house | 10      | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1.001 1.001, 1 1.001, 1 1 |
         And the ways
           | id | nodes |
@@ -142,6 +160,8 @@ Feature: Import of address interpolations
           | N1  | place | house | 2       | 1 1 |
           | N2  | place | house | 8       | 1.001 1.001 |
           | N3  | place | house | 7       | 1 1.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 1 1, 1 1.001, 1.001 1.001 |
         And the ways
           | id | nodes |
@@ -158,6 +178,8 @@ Feature: Import of address interpolations
           | N1  | place | house | 2       | 0 0 |
           | N2  | place | house | 6       | 0 0.001 |
           | N3  | place | house | 10      | 0 0.002 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 0 0, 0 0.001, 0 0.002, 0 0.001 |
         And the ways
           | id | nodes |
@@ -174,6 +196,8 @@ Feature: Import of address interpolations
           | osm | class | type  | housenr | geometry |
           | N1  | place | house | 2       | 0 0 |
           | N2  | place | house | 6       | 0 0.001 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W1  | place | houses | even    | 0 0, 0 0.001, 0 0.002, 0 0.001 |
         And the ways
           | id | nodes |
@@ -192,7 +216,7 @@ Feature: Import of address interpolations
           | N3  | place | house | 12      | :n-middle-w |
           | N4  | place | house | 16      | :n-middle-e |
         And the places
-          | osm | class   | type    | housenr | street       | geometry |
+          | osm | class   | type    | addr+interpolation | street       | geometry |
           | W10 | place   | houses  | even    |              | :w-middle |
           | W11 | place   | houses  | even    | Cloud Street | :w-middle |
         And the places
@@ -238,9 +262,9 @@ Feature: Import of address interpolations
           | N3  | place | house | 12      | Cloud Street | :n-middle-w |
           | N4  | place | house | 16      | Cloud Street | :n-middle-e |
         And the places
-          | osm | class   | type    | housenr | geometry |
-          | W10 | place   | houses  | even    | :w-middle |
-          | W11 | place   | houses  | even    | :w-middle |
+          | osm | class   | type    | addr+interpolation | geometry |
+          | W10 | place   | houses  | even               | :w-middle |
+          | W11 | place   | houses  | even               | :w-middle |
         And the places
           | osm | class   | type     | name         | geometry |
           | W2  | highway | tertiary | Sun Way      | :w-north |
@@ -277,7 +301,9 @@ Feature: Import of address interpolations
           | N1  | place | house       | 10      | 144.9632341 -37.76163 |
           | N2  | place | house       | 6       | 144.9630541 -37.7628174 |
           | N3  | shop  | supermarket | 2       | 144.9629794 -37.7630755 |
-          | W1  | place | houses      | even    | 144.9632341 -37.76163,144.9630541 -37.7628172,144.9629794 -37.7630755 |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
+          | W1  | place | houses | even    | 144.9632341 -37.76163,144.9630541 -37.7628172,144.9629794 -37.7630755 |
         And the ways
           | id | nodes |
           | 1  | 1,2,3 |
@@ -288,19 +314,23 @@ Feature: Import of address interpolations
           | 6     | 10  | 144.9630541 -37.7628174, 144.9632341 -37.76163 |
 
     Scenario: Place with missing address information
-        Given the places
-          | osm | class   | type   | housenr | geometry |
-          | N1  | place   | house  | 23      | 0.0001 0.0001 |
-          | N2  | amenity | school |         | 0.0001 0.0002 |
-          | N3  | place   | house  | 29      | 0.0001 0.0004 |
-          | W1  | place   | houses | odd     | 0.0001 0.0001,0.0001 0.0002,0.0001 0.0004 |
+        Given the grid
+          | 1 |  | 2 |  |  | 3 |
+        And the places
+          | osm | class   | type   | housenr |
+          | N1  | place   | house  | 23      |
+          | N2  | amenity | school |         |
+          | N3  | place   | house  | 29      |
+        And the places
+          | osm | class | type   | addr+interpolation | geometry |
+          | W1  | place | houses | odd                | 1,2,3 |
         And the ways
           | id | nodes |
           | 1  | 1,2,3 |
         When importing
         Then W1 expands to interpolation
           | start | end | geometry |
-          | 23    | 29  | 0.0001 0.0001, 0.0001 0.0002, 0.0001 0.0004 |
+          | 23    | 29  | 1,2,3 |
 
     Scenario: Ways without node entries are ignored
         Given the places

--- a/test/bdd/db/import/naming.feature
+++ b/test/bdd/db/import/naming.feature
@@ -8,8 +8,8 @@ Feature: Import and search of names
           | N1  | place | locality  | german | country:de |
         When importing
         Then placex contains
-          | object | calculated_country_code | name+name |
-          | N1     | de                      | german |
+          | object | country_code | name+name |
+          | N1     | de           | german |
 
     Scenario: Copying name tag to default language if it does not exist
         Given the places
@@ -17,8 +17,8 @@ Feature: Import and search of names
           | N1  | place | locality  | german | finnish      | country:de |
         When importing
         Then placex contains
-          | object | calculated_country_code | name   | name+name:fi | name+name:de |
-          | N1     | de                      | german | finnish      | german       |
+          | object | country_code | name   | name+name:fi | name+name:de |
+          | N1     | de           | german | finnish      | german       |
 
     Scenario: Copying default language name tag to name if it does not exist
         Given the places
@@ -26,8 +26,8 @@ Feature: Import and search of names
           | N1  | place | locality | german       | finnish      | country:de |
         When importing
         Then placex contains
-          | object | calculated_country_code | name   | name+name:fi | name+name:de |
-          | N1     | de                      | german | finnish      | german       |
+          | object | country_code | name   | name+name:fi | name+name:de |
+          | N1     | de           | german | finnish      | german       |
 
     Scenario: Do not overwrite default language with name tag
         Given the places
@@ -35,5 +35,5 @@ Feature: Import and search of names
           | N1  | place | locality | german | finnish      | local        | country:de |
         When importing
         Then placex contains
-          | object | calculated_country_code | name   | name+name:fi | name+name:de |
-          | N1     | de                      | german | finnish      | local        |
+          | object | country_code | name   | name+name:fi | name+name:de |
+          | N1     | de           | german | finnish      | local        |

--- a/test/bdd/db/import/parenting.feature
+++ b/test/bdd/db/import/parenting.feature
@@ -325,11 +325,11 @@ Feature: Parenting of objects
          | W3  | highway  | residential | foo  | :w-NS |
         When importing
         Then placex contains
-         | object | parent_place_id | street | addr_place | housenumber |
-         | W1     | W3              | foo    | nowhere    | 3 |
-         | N1     | W3              | foo    | nowhere    | 3 |
-         | N2     | W3              | foo    | nowhere    | 3 |
-         | N3     | W3              | foo    | nowhere    | 3 |
+         | object | parent_place_id | housenumber |
+         | W1     | W3              | 3 |
+         | N1     | W3              | 3 |
+         | N2     | W3              | 3 |
+         | N3     | W3              | 3 |
 
     Scenario: POIs don't inherit from streets
         Given the scene building-on-street-corner
@@ -344,8 +344,8 @@ Feature: Parenting of objects
          | W3  | highway  | residential | foo  | :w-NS |
         When importing
         Then placex contains
-         | object | parent_place_id | street | addr_place | housenumber |
-         | N1     | W3              | None   | None       | None |
+         | object | parent_place_id | housenumber |
+         | N1     | W3              | None |
 
     Scenario: POIs with own address do not inherit building address
         Given the scene building-on-street-corner
@@ -370,11 +370,11 @@ Feature: Parenting of objects
          | W3  | highway  | residential | foo  | :w-NS |
         When importing
         Then placex contains
-         | object | parent_place_id | street | addr_place | housenumber |
-         | W1     | N4              | None   | theplace   | 3 |
-         | N1     | W2              | bar    | None       | None |
-         | N2     | W3              | None   | None       | 4 |
-         | N3     | W2              | None   | nowhere    | None |
+         | object | parent_place_id | housenumber |
+         | W1     | N4              | 3 |
+         | N1     | W2              | None |
+         | N2     | W3              | 4 |
+         | N3     | W2              | None |
 
     Scenario: POIs parent a road if they are attached to it
         Given the scene points-on-roads

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -8,8 +8,8 @@ Feature: Import into placex
           | N1  | highway | primary  | country:us |
         When importing
         Then placex contains
-          | object | country_code | calculated_country_code |
-          | N1     | None         | us                      |
+          | object | addr+country | country_code |
+          | N1     | -            | us           |
 
     Scenario: Location overwrites country code tag
         Given the named places
@@ -17,8 +17,8 @@ Feature: Import into placex
           | N1  | highway | primary  | de      | country:us |
         When importing
         Then placex contains
-          | object | country_code | calculated_country_code |
-          | N1     | de           | us                      |
+          | object | addr+country | country_code |
+          | N1     | de           | us           |
 
     Scenario: Country code tag overwrites location for countries
         Given the named places
@@ -26,8 +26,8 @@ Feature: Import into placex
           | R1  | boundary | administrative  | 2     | de      | (-100 40, -101 40, -101 41, -100 41, -100 40) |
         When importing
         Then placex contains
-          | object | country_code | calculated_country_code |
-          | R1     | de           | de                      |
+          | object | addr+country | country_code |
+          | R1     | de           | de           |
 
     Scenario: Illegal country code tag for countries is ignored
         Given the named places
@@ -35,8 +35,8 @@ Feature: Import into placex
           | R1  | boundary | administrative  | 2     | xx      | (-100 40, -101 40, -101 41, -100 41, -100 40) |
         When importing
         Then placex contains
-          | object | country_code | calculated_country_code |
-          | R1     | xx           | us                      |
+          | object | addr+country | country_code |
+          | R1     | xx           | us           |
 
     Scenario: admin level is copied over
         Given the named places
@@ -46,24 +46,6 @@ Feature: Import into placex
         Then placex contains
           | object | admin_level |
           | N1     | 3           |
-
-    Scenario: admin level is default 15
-        Given the named places
-          | osm | class   | type   |
-          | N1  | amenity | prison |
-        When importing
-        Then placex contains
-          | object | admin_level |
-          | N1     | 15          |
-
-    Scenario: admin level is never larger than 15
-        Given the named places
-          | osm | class   | type   | admin |
-          | N1  | amenity | prison | 16 |
-        When importing
-        Then placex contains
-          | object | admin_level |
-          | N1     | 15          |
 
     Scenario: postcode node without postcode is dropped
         Given the places
@@ -87,10 +69,10 @@ Feature: Import into placex
          | N3   | place | postcode | Y45      | country:gb |
         When importing
         Then placex contains
-         | object | postcode | calculated_country_code | rank_search | rank_address |
-         | N1     | E45 2CD  | gb                      | 25          | 5 |
-         | N2     | E45 2    | gb                      | 23          | 5 |
-         | N3     | Y45      | gb                      | 21          | 5 |
+         | object | postcode | country_code | rank_search | rank_address |
+         | N1     | E45 2CD  | gb           | 25          | 5 |
+         | N2     | E45 2    | gb           | 23          | 5 |
+         | N3     | Y45      | gb           | 21          | 5 |
 
     Scenario: wrongly formatted GB postcodes are down-ranked
         Given the places
@@ -100,10 +82,10 @@ Feature: Import into placex
          | N3   | place | postcode | y45      | country:gb |
         When importing
         Then placex contains
-         | object | calculated_country_code | rank_search | rank_address |
-         | N1     | gb                      | 30          | 30 |
-         | N2     | gb                      | 30          | 30 |
-         | N3     | gb                      | 30          | 30 |
+         | object | country_code | rank_search | rank_address |
+         | N1     | gb           | 30          | 30 |
+         | N2     | gb           | 30          | 30 |
+         | N3     | gb           | 30          | 30 |
 
     Scenario: search and address rank for DE postcodes correctly assigned
         Given the places
@@ -114,11 +96,11 @@ Feature: Import into placex
          | N4  | place | postcode | 564276   | country:de |
         When importing
         Then placex contains
-         | object | calculated_country_code | rank_search | rank_address |
-         | N1     | de                      | 21          | 11 |
-         | N2     | de                      | 30          | 30 |
-         | N3     | de                      | 30          | 30 |
-         | N4     | de                      | 30          | 30 |
+         | object | country_code | rank_search | rank_address |
+         | N1     | de           | 21          | 11 |
+         | N2     | de           | 30          | 30 |
+         | N3     | de           | 30          | 30 |
+         | N4     | de           | 30          | 30 |
 
     Scenario: search and address rank for other postcodes are correctly assigned
         Given the places
@@ -134,16 +116,16 @@ Feature: Import into placex
          | N9  | place | postcode | A1:bc10  | country:ca |
         When importing
         Then placex contains
-         | object | calculated_country_code | rank_search | rank_address |
-         | N1     | ca                      | 21          | 11 |
-         | N2     | ca                      | 21          | 11 |
-         | N3     | ca                      | 21          | 11 |
-         | N4     | ca                      | 21          | 11 |
-         | N5     | ca                      | 21          | 11 |
-         | N6     | ca                      | 21          | 11 |
-         | N7     | ca                      | 25          | 11 |
-         | N8     | ca                      | 25          | 11 |
-         | N9     | ca                      | 25          | 11 |
+         | object | country_code | rank_search | rank_address |
+         | N1     | ca           | 21          | 11 |
+         | N2     | ca           | 21          | 11 |
+         | N3     | ca           | 21          | 11 |
+         | N4     | ca           | 21          | 11 |
+         | N5     | ca           | 21          | 11 |
+         | N6     | ca           | 21          | 11 |
+         | N7     | ca           | 25          | 11 |
+         | N8     | ca           | 25          | 11 |
+         | N9     | ca           | 25          | 11 |
 
     Scenario: search and address ranks for places are correctly assigned
         Given the named places

--- a/test/bdd/db/update/interpolation.feature
+++ b/test/bdd/db/update/interpolation.feature
@@ -17,7 +17,9 @@ Feature: Update of address interpolations
           | osm | class | type  | housenr | geometry |
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
-          | W10 | place | houses | even   | :w-middle |
+      And updating places
+          | osm | class | type   | addr+interpolation | geometry |
+          | W10 | place | houses | even               | :w-middle |
       Then placex contains
           | object | parent_place_id |
           | N1     | W2 |
@@ -32,6 +34,8 @@ Feature: Update of address interpolations
           | osm | class | type  | housenr | geometry |
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
+      And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W10 | place | houses | even   | :w-middle |
       And the places
           | osm | class   | type         | name         | geometry |
@@ -49,7 +53,7 @@ Feature: Update of address interpolations
           | parent_place_id | start | end |
           | W2              | 2     | 6 |
       When updating places
-          | osm | class   | type    | housenr | street       | geometry |
+          | osm | class   | type    | addr+interpolation | street       | geometry |
           | W10 | place   | houses  | even    | Cloud Street | :w-middle |
       Then placex contains
           | object | parent_place_id |
@@ -65,6 +69,8 @@ Feature: Update of address interpolations
           | osm | class | type  | housenr | geometry |
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
+      And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W10 | place | houses | even   | :w-middle |
       And the places
           | osm | class   | type         | name         | geometry |
@@ -99,6 +105,8 @@ Feature: Update of address interpolations
           | osm | class | type  | housenr | geometry |
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
+      And the places
+          | osm | class | type   | addr+interpolation | geometry |
           | W10 | place | houses | even   | :w-middle |
       And the places
           | osm | class   | type         | name         | geometry |
@@ -129,7 +137,7 @@ Feature: Update of address interpolations
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
       And the places
-          | osm | class   | type    | housenr | street      | geometry |
+          | osm | class   | type    | addr+interpolation | street      | geometry |
           | W10 | place   | houses  | even    | Cloud Street| :w-middle |
       And the places
           | osm | class   | type         | name     | geometry |
@@ -163,7 +171,7 @@ Feature: Update of address interpolations
           | N1  | place | house | 2       | :n-middle-w |
           | N2  | place | house | 6       | :n-middle-e |
       And the places
-          | osm | class   | type    | housenr | street      | geometry |
+          | osm | class   | type    | addr+interpolation | street      | geometry |
           | W10 | place   | houses  | even    | Cloud Street| :w-middle |
       And the places
           | osm | class   | type         | name         | geometry |
@@ -209,7 +217,7 @@ Feature: Update of address interpolations
           | N1  | place | house | 2       | :n-north-w |
           | N2  | place | house | 6       | :n-north-e |
       And updating places
-          | osm | class   | type    | housenr | street      | geometry |
+          | osm | class   | type    | addr+interpolation | street      | geometry |
           | W1  | place   | houses  | even    | Cloud Street| :w-north |
       Then placex has no entry for W1
       And W1 expands to interpolation
@@ -229,7 +237,7 @@ Feature: Update of address interpolations
           | id  | nodes |
           | 1   | 1,100,101,102,2 |
       And the places
-          | osm | class   | type    | housenr | street      | geometry |
+          | osm | class   | type    | addr+interpolation | street      | geometry |
           | W1  | place   | houses  | even    | Cloud Street| :w-north |
       When importing
       Then placex has no entry for W1
@@ -252,7 +260,7 @@ Feature: Update of address interpolations
           | id  | nodes |
           | 1   | 1,100,101,102,2 |
       And the places
-          | osm | class   | type    | housenr | geometry |
+          | osm | class   | type    | addr+interpolation | geometry |
           | W1  | place   | houses  | even    | :w-north |
       When importing
       Then W1 expands to no interpolation
@@ -261,7 +269,7 @@ Feature: Update of address interpolations
           | N1  | place | house | 2       | :n-north-w |
           | N2  | place | house | 6       | :n-north-e |
       And updating places
-          | osm | class   | type    | housenr | street      | geometry |
+          | osm | class   | type    | addr+interpolation | street      | geometry |
           | W1  | place   | houses  | even    | Cloud Street| :w-north |
       Then W1 expands to interpolation
           | parent_place_id | start | end |
@@ -279,7 +287,7 @@ Feature: Update of address interpolations
           | id  | nodes |
           | 2   | 3,4,5 |
       And the places
-          | osm | class   | type    | housenr | geometry |
+          | osm | class   | type    | addr+interpolation | geometry |
           | W2  | place   | houses  | even    | 3,4,5    |
       And the places
           | osm | class | type  | housenr |
@@ -309,7 +317,7 @@ Feature: Update of address interpolations
           | id  | nodes |
           | 2   | 3,4,5 |
       And the places
-          | osm | class   | type    | housenr | geometry |
+          | osm | class   | type    | addr+interpolation | geometry |
           | W2  | place   | houses  | even    | 3,4,5    |
       And the places
           | osm | class | type  | housenr |
@@ -338,7 +346,7 @@ Feature: Update of address interpolations
           | id  | nodes |
           | 2   | 3,4   |
       And the places
-          | osm | class   | type    | housenr | geometry |
+          | osm | class   | type    | addr+interpolation | geometry |
           | W2  | place   | houses  | even    | 3,4      |
       And the places
           | osm | class | type  | housenr |

--- a/test/bdd/osm2pgsql/update/relation.feature
+++ b/test/bdd/osm2pgsql/update/relation.feature
@@ -137,7 +137,7 @@ Feature: Update of relations by osm2pgsql
           r1 Ttype=boundary,boundary=administrative,name=Foo,country_code=XX,admin_level=2 Mw1@
           """
         Then place contains
-          | object | country_code | name           |
+          | object | addr+country | name           |
           | R1     | XX           | 'name' : 'Foo' |
 
     Scenario: Country boundary names are extended when country_code known
@@ -154,6 +154,6 @@ Feature: Update of relations by osm2pgsql
           r1 Ttype=boundary,boundary=administrative,name=Foo,country_code=ch,admin_level=2 Mw1@
           """
         Then place contains
-            | object | country_code | name+name:de | name+name |
+            | object | addr+country | name+name:de | name+name |
             | R1     | ch           | Schweiz      | Foo       |
 

--- a/test/bdd/steps/db_ops.py
+++ b/test/bdd/steps/db_ops.py
@@ -40,19 +40,24 @@ class PlaceColumn:
         self.columns['admin_level'] = int(value)
 
     def set_key_housenr(self, value):
-        self.add_hstore('address', 'housenumber', None if value == '' else value)
+        if value:
+            self.add_hstore('address', 'housenumber', value)
 
     def set_key_postcode(self, value):
-        self.add_hstore('address', 'postcode', None if value == '' else value)
+        if value:
+            self.add_hstore('address', 'postcode', value)
 
     def set_key_street(self, value):
-        self.add_hstore('address', 'street', None if value == '' else value)
+        if value:
+            self.add_hstore('address', 'street', value)
 
     def set_key_addr_place(self, value):
-        self.add_hstore('address', 'place', None if value == '' else value)
+        if value:
+            self.add_hstore('address', 'place', value)
 
     def set_key_country(self, value):
-        self.add_hstore('address', 'country', None if value == '' else value)
+        if value:
+            self.add_hstore('address', 'country', value)
 
     def set_key_geometry(self, value):
         self.geometry = self.context.osm.parse_geometry(value, self.context.scene)
@@ -103,9 +108,10 @@ class PlaceObjName(object):
         if self.pid is None:
             return "<null>"
 
-        self.conn.cursor().execute("""SELECT osm_type, osm_id, class
-                                      FROM placex WHERE place_id = %s""",
-                                   self.pid)
+        cur = self.conn.cursor()
+        cur.execute("""SELECT osm_type, osm_id, class
+                       FROM placex WHERE place_id = %s""",
+                    (self.pid, ))
         eq_(1, cur.rowcount, "No entry found for place id %s" % self.pid)
 
         return "%s%s:%s" % cur.fetchone()
@@ -432,7 +438,8 @@ def check_search_name_contents(context):
                                       FROM word, (SELECT unnest(%s) as term) t
                                       WHERE word_token = make_standard_name(t.term)""",
                                    (terms,))
-                    ok_(subcur.rowcount >= len(terms))
+                    ok_(subcur.rowcount >= len(terms),
+                        "No word entry found for " + row[h])
                     for wid in subcur:
                         assert_in(wid[0], res[h],
                                   "Missing term for %s/%s: %s" % (pid, h, wid[1]))

--- a/test/bdd/steps/osm_data.py
+++ b/test/bdd/steps/osm_data.py
@@ -79,14 +79,10 @@ def update_from_osm_file(context):
 
     cur = context.db.cursor()
     cur.execute("""insert into placex (osm_type, osm_id, class, type, name,
-                   admin_level,  housenumber, street, addr_place, isin, postcode,
-                   country_code, extratags, geometry) select * from place""")
+                   admin_level, address, extratags, geometry) select * from place""")
     cur.execute(
-        """insert into location_property_osmline
-               (osm_id, interpolationtype, street, addr_place,
-                postcode, calculated_country_code, linegeo)
-             SELECT osm_id, housenumber, street, addr_place,
-                    postcode, country_code, geometry from place
+        """insert into location_property_osmline (osm_id, address, linegeo)
+             SELECT osm_id, address, geometry from place
               WHERE class='place' and type='houses' and osm_type='W'
                     and ST_GeometryType(geometry) = 'ST_LineString'""")
     context.db.commit()

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -10,7 +10,7 @@ $sOutputFormat = 'html';
 
 $oDB =& getDB();
 
-$sSQL = "select placex.place_id, calculated_country_code as country_code,";
+$sSQL = "select placex.place_id, country_code,";
 $sSQL .= " name->'name' as name, i.* from placex, import_polygon_delete i";
 $sSQL .= " where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type";
 $sSQL .= " and placex.class = i.class and placex.type = i.type";

--- a/website/details.php
+++ b/website/details.php
@@ -83,7 +83,7 @@ $hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
 // Get the details for this point
 $sSQL = "SELECT place_id, osm_type, osm_id, class, type, name, admin_level,";
-$sSQL .= "    housenumber, street, postcode, country_code,";
+$sSQL .= "    housenumber, postcode, country_code,";
 $sSQL .= "    importance, wikipedia,";
 $sSQL .= "    to_char(indexed_date, 'YYYY-MM-DD HH24:MI') AS indexed_date,";
 $sSQL .= "    parent_place_id, ";

--- a/website/details.php
+++ b/website/details.php
@@ -83,7 +83,7 @@ $hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
 // Get the details for this point
 $sSQL = "SELECT place_id, osm_type, osm_id, class, type, name, admin_level,";
-$sSQL .= "    housenumber, street, isin, postcode, calculated_country_code AS country_code,";
+$sSQL .= "    housenumber, street, postcode, country_code,";
 $sSQL .= "    importance, wikipedia,";
 $sSQL .= "    to_char(indexed_date, 'YYYY-MM-DD HH24:MI') AS indexed_date,";
 $sSQL .= "    parent_place_id, ";


### PR DESCRIPTION
**This is a database-breaking change with no migration path. A full reimport is required.**

Replaces the `street`, `addr_place`, `is_in` and `country_code` column with a unified address hstore which contains all tagging information from the `addr:*` and `is_in:*` tags. The main advantage is that the new format retains the key information, so that the information can later be used to display addresses (see #148). This PR does not yet change anything in the address handling though, it just replaces the columns.

This will also contain a format change in the flatnode file, which happened in osm2pgsql. This is the other reason that a reimport is needed after this PR.

PR not yet complete, it requires https://github.com/openstreetmap/osm2pgsql/pull/737