### PR TITLE
DB column alignment and size

### DIFF
--- a/sql/loaddata.sql
+++ b/sql/loaddata.sql
@@ -6,8 +6,11 @@ TRUNCATE location_area;
 DROP SEQUENCE seq_place;
 CREATE SEQUENCE seq_place start 100000;
 
-insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry) select * from place where osm_type = 'N';
-insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry) select * from place where osm_type = 'W';
-insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry) select * from place where osm_type = 'R';
+insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry)
+             select osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry from place where osm_type = 'N';
+insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry)
+             select osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry from place where osm_type = 'W';
+insert into placex (osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry)
+             select osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, country_code, extratags, geometry from place where osm_type = 'R';
 
 --select count(*) from (select create_interpolation(osm_id, housenumber) from placex where indexed=false and class='place' and type='houses') as x;

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -65,13 +65,15 @@ BEGIN
   END IF;
 
   IF in_rank_search <= 4 THEN
-    INSERT INTO location_area_country values (in_partition, in_place_id, in_country_code, in_keywords, in_rank_search, in_rank_address, in_estimate, in_centroid, in_geometry);
+    INSERT INTO location_area_country (partition, place_id, country_code, keywords, rank_search, rank_address, isguess, centroid, geometry)
+      values (in_partition, in_place_id, in_country_code, in_keywords, in_rank_search, in_rank_address, in_estimate, in_centroid, in_geometry);
     RETURN TRUE;
   END IF;
 
 -- start
   IF in_partition = -partition- THEN
-    INSERT INTO location_area_large_-partition- values (in_partition, in_place_id, in_country_code, in_keywords, in_rank_search, in_rank_address, in_estimate, in_centroid, in_geometry);
+    INSERT INTO location_area_large_-partition- (partition, place_id, country_code, keywords, rank_search, rank_address, isguess, centroid, geometry)
+      values (in_partition, in_place_id, in_country_code, in_keywords, in_rank_search, in_rank_address, in_estimate, in_centroid, in_geometry);
     RETURN TRUE;
   END IF;
 -- end
@@ -203,14 +205,14 @@ DECLARE
 BEGIN
 
   DELETE FROM search_name WHERE place_id = in_place_id;
-  INSERT INTO search_name values (in_place_id, in_rank_search, in_rank_address, in_importance, in_country_code, 
-    in_name_vector, in_nameaddress_vector, in_centroid);
+  INSERT INTO search_name (place_id, search_rank, address_rank, importance, country_code, name_vector, nameaddress_vector, centroid)
+    values (in_place_id, in_rank_search, in_rank_address, in_importance, in_country_code, in_name_vector, in_nameaddress_vector, in_centroid);
 
   IF in_rank_search <= 4 THEN
     DELETE FROM search_name_country WHERE place_id = in_place_id;
     IF in_rank_address > 0 THEN
-      INSERT INTO search_name_country values (in_place_id, in_rank_search, in_rank_address,
-        in_name_vector, in_geometry);
+      INSERT INTO search_name_country (place_id, search_rank, address_rank, name_vector, centroid)
+        values (in_place_id, in_rank_search, in_rank_address, in_name_vector, in_geometry);
     END IF;
     RETURN TRUE;
   END IF;
@@ -219,8 +221,8 @@ BEGIN
   IF in_partition = -partition- THEN
     DELETE FROM search_name_-partition- values WHERE place_id = in_place_id;
     IF in_rank_address > 0 THEN
-      INSERT INTO search_name_-partition- values (in_place_id, in_rank_search, in_rank_address,
-        in_name_vector, in_geometry);
+      INSERT INTO search_name_-partition- (place_id, search_rank, address_rank, name_vector, centroid)
+        values (in_place_id, in_rank_search, in_rank_address, in_name_vector, in_geometry);
     END IF;
     RETURN TRUE;
   END IF;
@@ -261,7 +263,8 @@ BEGIN
 -- start
   IF in_partition = -partition- THEN
     DELETE FROM location_road_-partition- where place_id = in_place_id;
-    INSERT INTO location_road_-partition- values (in_partition, in_place_id, in_country_code, in_geometry);
+    INSERT INTO location_road_-partition- (partition, place_id, country_code, geometry)
+      values (in_partition, in_place_id, in_country_code, in_geometry);
     RETURN TRUE;
   END IF;
 -- end

--- a/sql/partition-tables.src.sql
+++ b/sql/partition-tables.src.sql
@@ -7,8 +7,8 @@ drop type if exists nearfeature cascade;
 create type nearfeature as (
   place_id BIGINT,
   keywords int[],
-  rank_address integer,
-  rank_search integer,
+  rank_address smallint,
+  rank_search smallint,
   distance float,
   isguess boolean
 );
@@ -17,8 +17,8 @@ drop type if exists nearfeaturecentr cascade;
 create type nearfeaturecentr as (
   place_id BIGINT,
   keywords int[],
-  rank_address integer,
-  rank_search integer,
+  rank_address smallint,
+  rank_search smallint,
   distance float,
   isguess boolean,
   centroid GEOMETRY
@@ -27,8 +27,8 @@ create type nearfeaturecentr as (
 drop table IF EXISTS search_name_blank CASCADE;
 CREATE TABLE search_name_blank (
   place_id BIGINT,
-  search_rank integer,
-  address_rank integer,
+  search_rank smallint,
+  address_rank smallint,
   name_vector integer[]
   );
 SELECT AddGeometryColumn('search_name_blank', 'centroid', 4326, 'GEOMETRY', 2);
@@ -52,8 +52,8 @@ CREATE INDEX idx_search_name_-partition-_centroid ON search_name_-partition- USI
 CREATE INDEX idx_search_name_-partition-_name_vector ON search_name_-partition- USING GIN (name_vector) WITH (fastupdate = off) {ts:address-index};
 
 CREATE TABLE location_road_-partition- (
-  partition integer,
   place_id BIGINT,
+  partition SMALLINT,
   country_code VARCHAR(2)
   ) {ts:address-data};
 SELECT AddGeometryColumn('location_road_-partition-', 'geometry', 4326, 'GEOMETRY', 2);

--- a/test/bdd/steps/db_ops.py
+++ b/test/bdd/steps/db_ops.py
@@ -278,9 +278,9 @@ def import_and_index_data_from_place_table(context):
     context.nominatim.run_setup_script('create-functions', 'create-partition-functions')
     cur = context.db.cursor()
     cur.execute(
-        """insert into placex (osm_type, osm_id, class, type, name, admin_level,
-           address, extratags, geometry)
-           select * from place where not (class='place' and type='houses' and osm_type='W')""")
+        """insert into placex (osm_type, osm_id, class, type, name, admin_level, address, extratags, geometry)
+           select              osm_type, osm_id, class, type, name, admin_level, address, extratags, geometry
+           from place where not (class='place' and type='houses' and osm_type='W')""")
     cur.execute(
             """insert into location_property_osmline (osm_id, address, linegeo)
              SELECT osm_id, address, geometry from place

--- a/test/bdd/steps/osm_data.py
+++ b/test/bdd/steps/osm_data.py
@@ -78,8 +78,8 @@ def update_from_osm_file(context):
     context.nominatim.run_setup_script('create-functions', 'create-partition-functions')
 
     cur = context.db.cursor()
-    cur.execute("""insert into placex (osm_type, osm_id, class, type, name,
-                   admin_level, address, extratags, geometry) select * from place""")
+    cur.execute("""insert into placex (osm_type, osm_id, class, type, name, admin_level, address, extratags, geometry)
+                     select            osm_type, osm_id, class, type, name, admin_level, address, extratags, geometry from place""")
     cur.execute(
         """insert into location_property_osmline (osm_id, address, linegeo)
              SELECT osm_id, address, geometry from place

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -360,13 +360,13 @@ if ($aCMDResult['load-data'] || $aCMDResult['all']) {
     }
 
     echo "Load Data\n";
+    $sColumns = 'osm_type, osm_id, class, type, name, admin_level, address, extratags, geometry';
+
     $aDBInstances = array();
     $iLoadThreads = max(1, $iInstances - 1);
     for ($i = 0; $i < $iLoadThreads; $i++) {
         $aDBInstances[$i] =& getDB(true);
-        $sSQL = 'insert into placex (osm_type, osm_id, class, type, name, admin_level, ';
-        $sSQL .= '                   address, extratags, geometry) ';
-        $sSQL .= 'select * from place where osm_id % '.$iLoadThreads.' = '.$i;
+        $sSQL = "INSERT INTO placex ($sColumns) SELECT $sColumns FROM place WHERE osm_id % $iLoadThreads = $i";
         $sSQL .= " and not (class='place' and type='houses' and osm_type='W' and ST_GeometryType(geometry) = 'ST_LineString')";
         if ($aCMDResult['verbose']) echo "$sSQL\n";
         if (!pg_send_query($aDBInstances[$i]->connection, $sSQL)) fail(pg_last_error($oDB->connection));

--- a/utils/update.php
+++ b/utils/update.php
@@ -166,6 +166,15 @@ if ($aResult['deduplicate']) {
     $aPartitions = chksql($oDB->getCol($sSQL));
     $aPartitions[] = 0;
 
+    // we don't care about empty search_name_* artitions, they can't contain mentions of duplicates
+    foreach ($aPartitions as $i => $sPartition) {
+        $sSQL = "select count(*) from search_name_".$sPartition;
+        $nEntries = chksql($oDB->getOne($sSQL));
+        if ($nEntries == 0) {
+            unset($aPartitions[$i]);
+        }
+    }
+
     $sSQL = "select word_token,count(*) from word where substr(word_token, 1, 1) = ' '";
     $sSQL .= " and class is null and type is null and country_code is null";
     $sSQL .= " group by word_token having count(*) > 1 order by word_token";

--- a/utils/update.php
+++ b/utils/update.php
@@ -156,12 +156,12 @@ if ($bHaveDiff) {
 }
 
 if ($aResult['deduplicate']) {
-    //
-    if (getPostgresVersion() < 9.3) {
+    $oDB =& getDB();
+
+    if (getPostgresVersion($oDB) < 9.3) {
         fail("ERROR: deduplicate is only currently supported in postgresql 9.3");
     }
 
-    $oDB =& getDB();
     $sSQL = 'select partition from country_name order by country_code';
     $aPartitions = chksql($oDB->getCol($sSQL));
     $aPartitions[] = 0;

--- a/utils/warm.php
+++ b/utils/warm.php
@@ -11,7 +11,7 @@ $aCMDOptions = array(
                 array('quiet', 'q', 0, 1, 0, 0, 'bool', 'Quiet output'),
                 array('verbose', 'v', 0, 1, 0, 0, 'bool', 'Verbose output'),
                 array('reverse-only', '', 0, 1, 0, 0, 'bool', 'Warm reverse only'),
-                array('search-only', '', 0, 1, 0, 0, 'bool', 'Warm reverse only'),
+                array('search-only', '', 0, 1, 0, 0, 'bool', 'Warm search only'),
                );
 getCmdOpt($_SERVER['argv'], $aCMDOptions, $aResult, true, true);
 

--- a/utils/warm.php
+++ b/utils/warm.php
@@ -53,7 +53,7 @@ if (!$aResult['search-only']) {
 }
 
 if (!$aResult['reverse-only']) {
-    $oGeocode =& new Nominatim\Geocode($oDB);
+    $oGeocode = new Nominatim\Geocode($oDB);
 
     echo "Warm search: ";
     if ($bVerbose) echo "\n";


### PR DESCRIPTION
PostgreSQL aligns column data (not just in RAM) based on the host CPU's alignment requirements / preferences. Most relevant for Nominatim is that `bigint`s are 8 byte aligned. Swapping the order of `osm_type` and `osm_id` columns consistently saves 6 bytes per row. Reducing the size of the ranks, `partition`, `index_status`, and `admin_level` from `integer` to `smallint` and re-ordering columns based on their alignment is simple and saves quite a bit of space.
To be able to change the order of columns, I had to change some SQL-statements to explicitly mention the columns INSERTed instead of relying on tables having a particular column order. There were surprisingly few such cases.

I currently need Nominatim for Germany, Switzerland, and Italy. The difference in table sizes of `place` and `placex` for freshly imported, indexed, VACUUM FULLed data before and after the changes seem worthwhile. This **should** also result in a (probably hard to meassure) speedup due to a smaller cache foot-print.

| table | original | reordered |
| ----- | -------- | --------- |
| place | 8522 MB | 8310 MB |
| placex | 16693 MB | 15519 MB |

This branch also contains several other trivial changes, which I can separate into other PRs if necessary. You can also just cherry-pick them.

Further space-savings seem possible, but will require more effort:
 * Use a `"char"` for `indexed_status` with values `'N'`, `'R'`, `'D'` and `NULL`, requiring no space for fully indexed places.
 * Use the [tinyint](https://pgxn.org/dist/tinyint/) extension instead of `smallint`.
 * Encode `osm_type` into the most significant byte of `osm_id`. — Especially interesting for indexes, which currently are still padded from 9 to 16 bytes.
 * Split the current `name HSTORE` into `name text, ref text, alt_names HSTORE`, so that the keys of `alt_names` are just the two character language code, and `alt_names` is `NULL` for most places. Don't store `alt_names` which are identical to `name`. — Will save at least 12 bytes for every named place.
 * Store geometries without SRID.
 * Determine if PostgreSQL ≥9.6 is consistently smart enough to use indices like `CREATE INDEX idx_place_classtype_shop_fish_centroid ON place USING gist (st_centroid(geometry)) WHERE class='shop' AND type='fish';` so that we could get rid of all the `place_classtype_*` tables.