### PR TITLE
Fix indentation in Vagrant instructions

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -43,10 +43,10 @@ is.
     
     See the FAQ how to skip this step and point Nominatim to an existing database.
 
-  ```
-  # inside the virtual machine:
-  mkdir data
-  cd build
+    ```
+    # inside the virtual machine:
+    mkdir data
+    cd build
     wget --no-verbose --output-document=../data/monaco.osm.pbf http://download.geofabrik.de/europe/monaco-latest.osm.pbf
     ./utils/setup.php --osm-file ../data/monaco.osm.pbf --osm2pgsql-cache 1000 --all 2>&1 | tee monaco.$$.log
     ```


### PR DESCRIPTION
Because of bad indentation, half the file was formatted as code.