### PR TITLE
limit number of considered places in POI queries

### DIFF
--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -52,7 +52,7 @@ Feature: Search queries
          | way |
 
     Scenario: Search with class-type feature
-        When sending jsonv2 search query "Hotel California"
+        When sending jsonv2 search query "Hotel in California"
         Then results contain
           | place_rank |
           | 30 |


### PR DESCRIPTION
When searching for POIs in place_classtype_ tables limit the number
of objects considered to 300. The distinct and order by clauses
forced until now to retrive all matching objects and order them
first which can cause long running queries when retriving them
for large areas like the US.

Fixes #735.