### PR TITLE
Update VAGRANT.md

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -47,13 +47,14 @@ is.
       # inside the virtual machine:
       mkdir data
       cd build
+      wget -O /home/vagrant/Nominatim/data/country_osm_grid.sql.gz http://www.nominatim.org/data/country_grid.sql.gz
       wget --no-verbose --output-document=../data/monaco.osm.pbf http://download.geofabrik.de/europe/monaco-latest.osm.pbf
       ./utils/setup.php --osm-file ../data/monaco.osm.pbf --osm2pgsql-cache 1000 --all 2>&1 | tee monaco.$$.log
       ```
 
     To repeat an import you'd need to delete the database first
 
-        dropdb -if-exists nominatim
+        dropdb --if-exists nominatim
 
 
 


### PR DESCRIPTION
Setup.php will not fail with below error anymore

> Error: you need to download the country_osm_grid first:
> wget -O /home/vagrant/Nominatim/data/country_osm_grid.sql.gz http://www.nominatim.org/data/country_grid.sql.gz