### PR TITLE
Warn about operation order with Wikipedia data

### DIFF
--- a/docs/Import-and-Update.md
+++ b/docs/Import-and-Update.md
@@ -39,6 +39,10 @@ This data is available as a binary download:
 Combined the 2 files are around 1.5GB and add around 30GB to the install
 size of nominatim. They also increase the install time by an hour or so.
 
+*NOTE:* you'll need to download the Wikipedia rankings before performing
+the initial import of the data if you want the rankings applied to the
+loaded data.
+
 ### UK postcodes
 
 Nominatim can use postcodes from an external source to improve searches that involve a UK postcode. This data can be optionally downloaded: 


### PR DESCRIPTION
Give first-time users a tip about installing Wikipedia data before performing initial import.
once [this issue](https://github.com/openstreetmap/Nominatim/issues/255) has been addressed, this note is no-longer important. Hoping a simple doc fix will help, since the cost of re-staging a database can be significant.