### PR TITLE
fix to NearPoint::extractFromQuery handling first minus sign

### DIFF
--- a/lib/NearPoint.php
+++ b/lib/NearPoint.php
@@ -133,8 +133,8 @@ class NearPoint
             $sFound    = $aData[0];
             $fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
             $fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
-        } elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
-            /*                 1          2                             3                        4
+        } elseif (preg_match('/(\\[|^|\\b)?(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
+            /*                 1           2                             3                        4
              * degrees decimal
              * 12.34, 56.78
              * [12.456,-78.90]

--- a/test/php/Nominatim/NearPointTest.php
+++ b/test/php/Nominatim/NearPointTest.php
@@ -35,6 +35,10 @@ class NearPointTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($aRes['pt']->radius(), 0.1);
         $this->assertEquals($aRes['query'], '');
 
+        $aRes = NearPoint::extractFromQuery(' -12.456,-78.90 ');
+        $this->assertEquals($aRes['pt']->lat(), -12.456);
+        $this->assertEquals($aRes['pt']->lon(), -78.90);
+
         // http://en.wikipedia.org/wiki/Geographic_coordinate_conversion
         // these all represent the same location
         $aQueries = array(


### PR DESCRIPTION
for https://github.com/openstreetmap/Nominatim/issues/797