### PR TITLE
NearPoint::extractFromQuery - greedy-match optional quote sign

### DIFF
--- a/lib/NearPoint.php
+++ b/lib/NearPoint.php
@@ -81,8 +81,8 @@ class NearPoint
         $fQueryLat = null;
         $fQueryLon = null;
 
-        if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData)) {
-            /*              1         2                   3                  4         5            6
+        if (preg_match('/\\s*([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*\\s*/', $sQuery, $aData)) {
+            /*               1         2                   3                    4         5            6
              * degrees decimal minutes
              * N 40 26.767, W 79 58.933
              * N 40°26.767′, W 79°58.933′
@@ -90,8 +90,8 @@ class NearPoint
             $sFound    = $aData[0];
             $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
             $fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
-        } elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData)) {
-            /*                    1             2                      3          4            5                    6
+        } elseif (preg_match('/\\s*([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\s*/', $sQuery, $aData)) {
+            /*                     1            2                         3          4            5                      6
              * degrees decimal minutes
              * 40 26.767 N, 79 58.933 W
              * 40° 26.767′ N 79° 58.933′ W
@@ -99,8 +99,8 @@ class NearPoint
             $sFound    = $aData[0];
             $fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
             $fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
-        } elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData)) {
-            /*                    1        2            3            4                5        6            7            8
+        } elseif (preg_match('/\\s*([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\s*/', $sQuery, $aData)) {
+            /*                     1        2            3              4                 5        6            7              8
              * degrees decimal seconds
              * N 40 26 46 W 79 58 56
              * N 40° 26′ 46″, W 79° 58′ 56″
@@ -108,8 +108,8 @@ class NearPoint
             $sFound    = $aData[0];
             $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
             $fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
-        } elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData)) {
-            /*                    1            2            3            4          5            6            7            8
+        } elseif (preg_match('/\\s*([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\s*/', $sQuery, $aData)) {
+            /*                     1            2              3             4          5            6              7             8
              * degrees decimal seconds
              * 40 26 46 N 79 58 56 W
              * 40° 26′ 46″ N, 79° 58′ 56″ W
@@ -117,26 +117,27 @@ class NearPoint
             $sFound    = $aData[0];
             $fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
             $fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
-        } elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData)) {
-            /*                    1        2                               3        4
+        } elseif (preg_match('/\\s*([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\s*/', $sQuery, $aData)) {
+            /*                     1        2                               3        4
              * degrees decimal
              * N 40.446° W 79.982°
              */
             $sFound    = $aData[0];
             $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
             $fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
-        } elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData)) {
-            /*                    1                           2          3                           4
+        } elseif (preg_match('/\\s*([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\s*/', $sQuery, $aData)) {
+            /*                     1                           2          3                           4
              * degrees decimal
              * 40.446° N 79.982° W
              */
             $sFound    = $aData[0];
             $fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
             $fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
-        } elseif (preg_match('/(\\[|^|\\b)?(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
-            /*                 1           2                             3                        4
+        } elseif (preg_match('/(\\s*\\[|^\\s*|\\s*)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]\\s*|\\s*$|\\s*)/', $sQuery, $aData)) {
+            /*                 1                   2                             3                        4
              * degrees decimal
              * 12.34, 56.78
+             * 12.34 56.78
              * [12.456,-78.90]
              */
             $sFound    = $aData[0];

--- a/test/php/Nominatim/NearPointTest.php
+++ b/test/php/Nominatim/NearPointTest.php
@@ -27,7 +27,7 @@ class NearPointTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($aRes['pt']->lat(), 12.456);
         $this->assertEquals($aRes['pt']->lon(), -78.90);
         $this->assertEquals($aRes['pt']->radius(), 0.1);
-        $this->assertEquals($aRes['query'], 'abc   def');
+        $this->assertEquals($aRes['query'], 'abc def');
 
         $aRes = NearPoint::extractFromQuery(' [12.456,-78.90] ');
         $this->assertEquals($aRes['pt']->lat(), 12.456);
@@ -69,6 +69,7 @@ class NearPointTest extends \PHPUnit_Framework_TestCase
             $aRes = NearPoint::extractFromQuery($sQuery);
             $this->assertEquals(40.446, $aRes['pt']->lat(), 'degrees decimal ' . $sQuery, 0.01);
             $this->assertEquals(-79.982, $aRes['pt']->lon(), 'degrees decimal ' . $sQuery, 0.01);
+            $this->assertEquals('', $aRes['query']);
         }
     }
 


### PR DESCRIPTION
(second) fix for https://github.com/openstreetmap/Nominatim/issues/797