### PR TITLE
add index.php

### DIFF
--- a/website/index.php
+++ b/website/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/search.php';


### PR DESCRIPTION
- usual file that webservers expect
- search.php seems to be capable of this role
- not having this file makes a fresh install seem nonfunctional ("install Nominatim, go to localhost:8080, see a 403")
- not implemented as a symlink, as not all filesystems support them