### PR TITLE
Ui allow copypaste combined latlon

### DIFF
--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -15,7 +15,7 @@
             <input name="format" type="hidden" value="html">
             lat
             <input name="lat" type="text" class="form-control input-sm" placeholder="latitude" value="<?php echo $fLat; ?>" >
-            <span id="switch-coords" title="switch lat and lon">&lt;&gt;</span>
+            <button class="btn btn-default btn-xs" id="switch-coords" title="switch lat and lon">&lt;&gt;</button>
             lon
             <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo $fLon; ?>" >
             max zoom

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -15,7 +15,7 @@
             <input name="format" type="hidden" value="html">
             lat
             <input name="lat" type="text" class="form-control input-sm" placeholder="latitude" value="<?php echo $fLat; ?>" >
-            <button class="btn btn-default btn-xs" id="switch-coords" title="switch lat and lon">&lt;&gt;</button>
+            <a href="#" class="btn btn-default btn-xs" id="switch-coords" title="switch lat and lon">&lt;&gt;</a>
             lon
             <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo $fLon; ?>" >
             max zoom

--- a/website/js/nominatim-ui.js
+++ b/website/js/nominatim-ui.js
@@ -248,6 +248,14 @@ jQuery(document).on('ready', function(){
 
     highlight_result(0, false);
 
+    // common mistake is to copy&paste latitude and longitude into the 'lat' search box
+    $('form input[name=lat]').on('change', function(){
+        var coords = $(this).val().split(',');
+        if (coords.length == 2) {
+            $(this).val(coords[0]);
+            $(this).siblings('input[name=lon]').val(coords[1]);
+        }
+    });
 
 });
 

--- a/website/js/nominatim-ui.js
+++ b/website/js/nominatim-ui.js
@@ -198,15 +198,18 @@ jQuery(document).on('ready', function(){
             }
         }
         else {
-            if ( is_reverse_search ){
-                // make sure the search coordinates are in the map view as well
-                map.fitBounds([[result.lat,result.lon], [nominatim_map_init.lat,nominatim_map_init.lon]], {padding: [50,50], maxZoom: map.getZoom()});
+            var result_coord = L.latLng(result.lat, result.lon);
+            if ( result_coord ){
+                if ( is_reverse_search ){
+                    // make sure the search coordinates are in the map view as well
+                    map.fitBounds([result_coord, [nominatim_map_init.lat,nominatim_map_init.lon]], {padding: [50,50], maxZoom: map.getZoom()});
 
-                // better, but causes a leaflet warning
-                // map.panInsideBounds([[result.lat,result.lon], [nominatim_map_init.lat,nominatim_map_init.lon]], {animate: false});
-            }
-            else {
-                map.panTo([result.lat,result.lon], result.zoom || nominatim_map_init.zoom);
+                    // better, but causes a leaflet warning
+                    // map.panInsideBounds([[result.lat,result.lon], [nominatim_map_init.lat,nominatim_map_init.lon]], {animate: false});
+                }
+                else {
+                    map.panTo(result_coord, result.zoom || nominatim_map_init.zoom);
+                }
             }
         }
 
@@ -238,6 +241,8 @@ jQuery(document).on('ready', function(){
         });
 
         $('#switch-coords').on('click', function(e){
+            e.preventDefault();
+            e.stopPropagation();
             var lat = $('form input[name=lat]').val();
             var lon = $('form input[name=lon]').val();
             $('form input[name=lat]').val(lon);
@@ -252,8 +257,8 @@ jQuery(document).on('ready', function(){
     $('form input[name=lat]').on('change', function(){
         var coords = $(this).val().split(',');
         if (coords.length == 2) {
-            $(this).val(coords[0]);
-            $(this).siblings('input[name=lon]').val(coords[1]);
+            $(this).val(L.Util.trim(coords[0]));
+            $(this).siblings('input[name=lon]').val(L.Util.trim(coords[1]));
         }
     });
 


### PR DESCRIPTION
* on the reverse search page you can copy&paste a string like `56.78, 12.34`
* when entering invalid coordinates `map.fitBounds` croaked
* make the "switch lat and lon" value feature more visible