### PR TITLE
PHP code style rule to enforce single quotes

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -129,6 +129,23 @@
 
 
 
+
+  <!-- **************************************************************
+       STRING QUOTING
+       ************************************************************** -->
+
+  <!-- Prefer single quoted strings -->
+  <rule ref="Squiz.Strings.DoubleQuoteUsage" />
+
+  <!-- We allow variabled inside double-quoted strings "abc $somevar" -->
+  <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+    <severity>0</severity>
+  </rule>
+
+
+
+
+
   <!-- **************************************************************
        CONTROL STRUCTURES
        ************************************************************** -->


### PR DESCRIPTION
This PR contains only the rules. About 900 lines affected.

Using `phpcbf */**.php` you can autofix them all.

Watch out (`git diff`) for lines like `"abc \"de\" fg"` where single-quoting will cause the backslash to be in the output.