### PR TITLE
Use PlaceLookup in search for retriving place details

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -45,7 +45,6 @@ class Geocode
     protected $iMinAddressRank = 0;
     protected $iMaxAddressRank = 30;
     protected $aAddressRankList = array();
-    protected $exactMatchCache = array();
 
     protected $sAllowedTypesSQLList = false;
 
@@ -365,298 +364,320 @@ class Geocode
         return false;
     }
 
-    public function getDetails($aPlaceIDs, $oCtx)
+    public function getDetails($aResults, $oCtx)
     {
-        //$aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
-        if (sizeof($aPlaceIDs) == 0) return array();
+        // Get the details for display (is this a redundant extra step?)
+        //$aResults is an array of Result objects
+        if (sizeof($aResults) == 0) return array();
 
         $sLanguagePrefArraySQL = getArraySQL(
             array_map("getDBQuoted", $this->aLangPrefOrder)
         );
 
-        // Get the details for display (is this a redundant extra step?)
-        $sPlaceIDs = join(',', array_keys($aPlaceIDs));
-
         $sImportanceSQL = $oCtx->viewboxImportanceSQL('ST_Collect(centroid)');
         $sImportanceSQLGeom = $oCtx->viewboxImportanceSQL('geometry');
 
-        $sSQL  = "SELECT ";
-        $sSQL .= "    osm_type,";
-        $sSQL .= "    osm_id,";
-        $sSQL .= "    class,";
-        $sSQL .= "    type,";
-        $sSQL .= "    admin_level,";
-        $sSQL .= "    rank_search,";
-        $sSQL .= "    rank_address,";
-        $sSQL .= "    min(place_id) AS place_id, ";
-        $sSQL .= "    min(parent_place_id) AS parent_place_id, ";
-        $sSQL .= "    country_code, ";
-        $sSQL .= "    get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress,";
-        $sSQL .= "    get_name_by_language(name, $sLanguagePrefArraySQL) AS placename,";
-        $sSQL .= "    get_name_by_language(name, ARRAY['ref']) AS ref,";
-        if ($this->bIncludeExtraTags) $sSQL .= "hstore_to_json(extratags)::text AS extra,";
-        if ($this->bIncludeNameDetails) $sSQL .= "hstore_to_json(name)::text AS names,";
-        $sSQL .= "    avg(ST_X(centroid)) AS lon, ";
-        $sSQL .= "    avg(ST_Y(centroid)) AS lat, ";
-        $sSQL .= "    COALESCE(importance,0.75-(rank_search::float/40)) $sImportanceSQL AS importance, ";
-        if ($oCtx->hasNearPoint()) {
-            $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
-        } else {
-            $sSQL .= "    ( ";
-            $sSQL .= "       SELECT max(p.importance*(p.rank_address+2))";
-            $sSQL .= "       FROM ";
-            $sSQL .= "         place_addressline s, ";
-            $sSQL .= "         placex p";
-            $sSQL .= "       WHERE s.place_id = min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END)";
-            $sSQL .= "         AND p.place_id = s.address_place_id ";
-            $sSQL .= "         AND s.isaddress ";
-            $sSQL .= "         AND p.importance is not null ";
-            $sSQL .= "    ) AS addressimportance, ";
-        }
-        $sSQL .= "    (extratags->'place') AS extra_place ";
-        $sSQL .= " FROM placex";
-        $sSQL .= " WHERE place_id in ($sPlaceIDs) ";
-        $sSQL .= "   AND (";
-        $sSQL .= "            placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-        if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) {
-            $sSQL .= "        OR (extratags->'place') = 'city'";
-        }
-        if ($this->aAddressRankList) {
-            $sSQL .= "        OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
-        }
-        $sSQL .= "       ) ";
-        if ($this->sAllowedTypesSQLList) {
-            $sSQL .= "AND placex.class in $this->sAllowedTypesSQLList ";
-        }
-        $sSQL .= "    AND linked_place_id is null ";
-        $sSQL .= " GROUP BY ";
-        $sSQL .= "     osm_type, ";
-        $sSQL .= "     osm_id, ";
-        $sSQL .= "     class, ";
-        $sSQL .= "     type, ";
-        $sSQL .= "     admin_level, ";
-        $sSQL .= "     rank_search, ";
-        $sSQL .= "     rank_address, ";
-        $sSQL .= "     country_code, ";
-        $sSQL .= "     importance, ";
-        if (!$this->bDeDupe) $sSQL .= "place_id,";
-        $sSQL .= "     langaddress, ";
-        $sSQL .= "     placename, ";
-        $sSQL .= "     ref, ";
-        if ($this->bIncludeExtraTags) $sSQL .= "extratags, ";
-        if ($this->bIncludeNameDetails) $sSQL .= "name, ";
-        $sSQL .= "     extratags->'place' ";
+        $aSubSelects = array();
 
-        // postcode table
-        $sSQL .= "UNION ";
-        $sSQL .= "SELECT";
-        $sSQL .= "  'P' as osm_type,";
-        $sSQL .= "  (SELECT osm_id from placex p WHERE p.place_id = lp.parent_place_id) as osm_id,";
-        $sSQL .= "  'place' as class, 'postcode' as type,";
-        $sSQL .= "  null as admin_level, rank_search, rank_address,";
-        $sSQL .= "  place_id, parent_place_id, country_code,";
-        $sSQL .= "  get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress,";
-        $sSQL .= "  postcode as placename,";
-        $sSQL .= "  postcode as ref,";
-        if ($this->bIncludeExtraTags) $sSQL .= "null AS extra,";
-        if ($this->bIncludeNameDetails) $sSQL .= "null AS names,";
-        $sSQL .= "  ST_x(st_centroid(geometry)) AS lon, ST_y(st_centroid(geometry)) AS lat,";
-        $sSQL .= "  (0.75-(rank_search::float/40)) $sImportanceSQLGeom AS importance, ";
-        if ($oCtx->hasNearPoint()) {
-            $sSQL .= $oCtx->distanceSQL('geometry')." AS addressimportance,";
-        } else {
-            $sSQL .= "  (";
-            $sSQL .= "     SELECT max(p.importance*(p.rank_address+2))";
-            $sSQL .= "     FROM ";
-            $sSQL .= "       place_addressline s, ";
-            $sSQL .= "       placex p";
-            $sSQL .= "     WHERE s.place_id = lp.parent_place_id";
-            $sSQL .= "       AND p.place_id = s.address_place_id ";
-            $sSQL .= "       AND s.isaddress";
-            $sSQL .= "       AND p.importance is not null";
-            $sSQL .= "  ) AS addressimportance, ";
-        }
-        $sSQL .= "  null AS extra_place ";
-        $sSQL .= "FROM location_postcode lp";
-        $sSQL .= " WHERE place_id in ($sPlaceIDs) ";
-
-        if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank) {
-            // only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines
-            // with start- and endnumber, the common osm housenumbers are usually saved as points
-            $sHousenumbers = "";
-            $i = 0;
-            $length = count($aPlaceIDs);
-            foreach ($aPlaceIDs as $placeID => $housenumber) {
-                $i++;
-                $sHousenumbers .= "(".$placeID.", ".$housenumber.")";
-                if ($i<$length) $sHousenumbers .= ", ";
-            }
-
-            if (CONST_Use_US_Tiger_Data) {
-                // Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
-                $sSQL .= " union";
-                $sSQL .= " SELECT ";
-                $sSQL .= "     'T' AS osm_type, ";
-                $sSQL .= "     (SELECT osm_id from placex p WHERE p.place_id=min(blub.parent_place_id)) as osm_id, ";
-                $sSQL .= "     'place' AS class, ";
-                $sSQL .= "     'house' AS type, ";
-                $sSQL .= "     null AS admin_level, ";
-                $sSQL .= "     30 AS rank_search, ";
-                $sSQL .= "     30 AS rank_address, ";
-                $sSQL .= "     min(place_id) AS place_id, ";
-                $sSQL .= "     min(parent_place_id) AS parent_place_id, ";
-                $sSQL .= "     'us' AS country_code, ";
-                $sSQL .= "     get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) AS langaddress,";
-                $sSQL .= "     null AS placename, ";
-                $sSQL .= "     null AS ref, ";
-                if ($this->bIncludeExtraTags) $sSQL .= "null AS extra,";
-                if ($this->bIncludeNameDetails) $sSQL .= "null AS names,";
-                $sSQL .= "     avg(st_x(centroid)) AS lon, ";
-                $sSQL .= "     avg(st_y(centroid)) AS lat,";
-                $sSQL .= "     -1.15".$sImportanceSQL." AS importance, ";
-                if ($oCtx->hasNearPoint()) {
-                    $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
-                } else {
-                    $sSQL .= "     (";
-                    $sSQL .= "        SELECT max(p.importance*(p.rank_address+2))";
-                    $sSQL .= "        FROM ";
-                    $sSQL .= "          place_addressline s, ";
-                    $sSQL .= "          placex p";
-                    $sSQL .= "        WHERE s.place_id = min(blub.parent_place_id)";
-                    $sSQL .= "          AND p.place_id = s.address_place_id ";
-                    $sSQL .= "          AND s.isaddress";
-                    $sSQL .= "          AND p.importance is not null";
-                    $sSQL .= "     ) AS addressimportance, ";
-                }
-                $sSQL .= "     null AS extra_place ";
-                $sSQL .= " FROM (";
-                $sSQL .= "     SELECT place_id, ";    // interpolate the Tiger housenumbers here
-                $sSQL .= "         ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) AS centroid, ";
-                $sSQL .= "         parent_place_id, ";
-                $sSQL .= "         housenumber_for_place";
-                $sSQL .= "     FROM (";
-                $sSQL .= "            location_property_tiger ";
-                $sSQL .= "            JOIN (values ".$sHousenumbers.") AS housenumbers(place_id, housenumber_for_place) USING(place_id)) ";
-                $sSQL .= "     WHERE ";
-                $sSQL .= "         housenumber_for_place>=0";
-                $sSQL .= "         AND 30 between $this->iMinAddressRank AND $this->iMaxAddressRank";
-                $sSQL .= " ) AS blub"; //postgres wants an alias here
-                $sSQL .= " GROUP BY";
-                $sSQL .= "      place_id, ";
-                $sSQL .= "      housenumber_for_place"; //is this group by really needed?, place_id + housenumber (in combination) are unique
-                if (!$this->bDeDupe) $sSQL .= ", place_id ";
-            }
-            // osmline
-            // interpolation line search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
-            $sSQL .= " UNION ";
-            $sSQL .= "SELECT ";
-            $sSQL .= "  'W' AS osm_type, ";
-            $sSQL .= "  osm_id, ";
-            $sSQL .= "  'place' AS class, ";
-            $sSQL .= "  'house' AS type, ";
-            $sSQL .= "  null AS admin_level, ";
-            $sSQL .= "  30 AS rank_search, ";
-            $sSQL .= "  30 AS rank_address, ";
-            $sSQL .= "  min(place_id) as place_id, ";
-            $sSQL .= "  min(parent_place_id) AS parent_place_id, ";
-            $sSQL .= "  country_code, ";
-            $sSQL .= "  get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) AS langaddress, ";
-            $sSQL .= "  null AS placename, ";
-            $sSQL .= "  null AS ref, ";
-            if ($this->bIncludeExtraTags) $sSQL .= "null AS extra, ";
-            if ($this->bIncludeNameDetails) $sSQL .= "null AS names, ";
-            $sSQL .= "  AVG(st_x(centroid)) AS lon, ";
-            $sSQL .= "  AVG(st_y(centroid)) AS lat, ";
-            $sSQL .= "  -0.1".$sImportanceSQL." AS importance, ";  // slightly smaller than the importance for normal houses with rank 30, which is 0
+        $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_PLACEX);
+        if ($sPlaceIDs) {
+            $sSQL  = "SELECT ";
+            $sSQL .= "    osm_type,";
+            $sSQL .= "    osm_id,";
+            $sSQL .= "    class,";
+            $sSQL .= "    type,";
+            $sSQL .= "    admin_level,";
+            $sSQL .= "    rank_search,";
+            $sSQL .= "    rank_address,";
+            $sSQL .= "    min(place_id) AS place_id, ";
+            $sSQL .= "    min(parent_place_id) AS parent_place_id, ";
+            $sSQL .= "    country_code, ";
+            $sSQL .= "    get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress,";
+            $sSQL .= "    get_name_by_language(name, $sLanguagePrefArraySQL) AS placename,";
+            $sSQL .= "    get_name_by_language(name, ARRAY['ref']) AS ref,";
+            if ($this->bIncludeExtraTags) $sSQL .= "hstore_to_json(extratags)::text AS extra,";
+            if ($this->bIncludeNameDetails) $sSQL .= "hstore_to_json(name)::text AS names,";
+            $sSQL .= "    avg(ST_X(centroid)) AS lon, ";
+            $sSQL .= "    avg(ST_Y(centroid)) AS lat, ";
+            $sSQL .= "    COALESCE(importance,0.75-(rank_search::float/40)) $sImportanceSQL AS importance, ";
             if ($oCtx->hasNearPoint()) {
                 $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
             } else {
+                $sSQL .= "    ( ";
+                $sSQL .= "       SELECT max(p.importance*(p.rank_address+2))";
+                $sSQL .= "       FROM ";
+                $sSQL .= "         place_addressline s, ";
+                $sSQL .= "         placex p";
+                $sSQL .= "       WHERE s.place_id = min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END)";
+                $sSQL .= "         AND p.place_id = s.address_place_id ";
+                $sSQL .= "         AND s.isaddress ";
+                $sSQL .= "         AND p.importance is not null ";
+                $sSQL .= "    ) AS addressimportance, ";
+            }
+            $sSQL .= "    (extratags->'place') AS extra_place ";
+            $sSQL .= " FROM placex";
+            $sSQL .= " WHERE place_id in ($sPlaceIDs) ";
+            $sSQL .= "   AND (";
+            $sSQL .= "            placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
+            if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) {
+                $sSQL .= "        OR (extratags->'place') = 'city'";
+            }
+            if ($this->aAddressRankList) {
+                $sSQL .= "        OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
+            }
+            $sSQL .= "       ) ";
+            if ($this->sAllowedTypesSQLList) {
+                $sSQL .= "AND placex.class in $this->sAllowedTypesSQLList ";
+            }
+            $sSQL .= "    AND linked_place_id is null ";
+            $sSQL .= " GROUP BY ";
+            $sSQL .= "     osm_type, ";
+            $sSQL .= "     osm_id, ";
+            $sSQL .= "     class, ";
+            $sSQL .= "     type, ";
+            $sSQL .= "     admin_level, ";
+            $sSQL .= "     rank_search, ";
+            $sSQL .= "     rank_address, ";
+            $sSQL .= "     country_code, ";
+            $sSQL .= "     importance, ";
+            if (!$this->bDeDupe) $sSQL .= "place_id,";
+            $sSQL .= "     langaddress, ";
+            $sSQL .= "     placename, ";
+            $sSQL .= "     ref, ";
+            if ($this->bIncludeExtraTags) $sSQL .= "extratags, ";
+            if ($this->bIncludeNameDetails) $sSQL .= "name, ";
+            $sSQL .= "     extratags->'place' ";
+
+            $aSubSelects[] = $sSQL;
+        }
+
+        // postcode table
+        $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_POSTCODE);
+        if ($sPlaceIDs) {
+            $sSQL = 'SELECT';
+            $sSQL .= "  'P' as osm_type,";
+            $sSQL .= "  (SELECT osm_id from placex p WHERE p.place_id = lp.parent_place_id) as osm_id,";
+            $sSQL .= "  'place' as class, 'postcode' as type,";
+            $sSQL .= "  null as admin_level, rank_search, rank_address,";
+            $sSQL .= "  place_id, parent_place_id, country_code,";
+            $sSQL .= "  get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress,";
+            $sSQL .= "  postcode as placename,";
+            $sSQL .= "  postcode as ref,";
+            if ($this->bIncludeExtraTags) $sSQL .= "null AS extra,";
+            if ($this->bIncludeNameDetails) $sSQL .= "null AS names,";
+            $sSQL .= "  ST_x(st_centroid(geometry)) AS lon, ST_y(st_centroid(geometry)) AS lat,";
+            $sSQL .= "  (0.75-(rank_search::float/40)) $sImportanceSQLGeom AS importance, ";
+            if ($oCtx->hasNearPoint()) {
+                $sSQL .= $oCtx->distanceSQL('geometry')." AS addressimportance,";
+            } else {
                 $sSQL .= "  (";
-                $sSQL .= "     SELECT ";
-                $sSQL .= "       MAX(p.importance*(p.rank_address+2)) ";
-                $sSQL .= "     FROM";
+                $sSQL .= "     SELECT max(p.importance*(p.rank_address+2))";
+                $sSQL .= "     FROM ";
                 $sSQL .= "       place_addressline s, ";
                 $sSQL .= "       placex p";
-                $sSQL .= "     WHERE s.place_id = min(blub.parent_place_id) ";
+                $sSQL .= "     WHERE s.place_id = lp.parent_place_id";
                 $sSQL .= "       AND p.place_id = s.address_place_id ";
-                $sSQL .= "       AND s.isaddress ";
+                $sSQL .= "       AND s.isaddress";
                 $sSQL .= "       AND p.importance is not null";
-                $sSQL .= "  ) AS addressimportance,";
+                $sSQL .= "  ) AS addressimportance, ";
             }
             $sSQL .= "  null AS extra_place ";
-            $sSQL .= "  FROM (";
-            $sSQL .= "     SELECT ";
-            $sSQL .= "         osm_id, ";
-            $sSQL .= "         place_id, ";
-            $sSQL .= "         country_code, ";
-            $sSQL .= "         CASE ";             // interpolate the housenumbers here
-            $sSQL .= "           WHEN startnumber != endnumber ";
-            $sSQL .= "           THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
-            $sSQL .= "           ELSE ST_LineInterpolatePoint(linegeo, 0.5) ";
-            $sSQL .= "         END as centroid, ";
-            $sSQL .= "         parent_place_id, ";
-            $sSQL .= "         housenumber_for_place ";
-            $sSQL .= "     FROM (";
-            $sSQL .= "            location_property_osmline ";
-            $sSQL .= "            JOIN (values ".$sHousenumbers.") AS housenumbers(place_id, housenumber_for_place) USING(place_id)";
-            $sSQL .= "          ) ";
-            $sSQL .= "     WHERE housenumber_for_place>=0 ";
-            $sSQL .= "       AND 30 between $this->iMinAddressRank AND $this->iMaxAddressRank";
-            $sSQL .= "  ) as blub"; //postgres wants an alias here
-            $sSQL .= "  GROUP BY ";
-            $sSQL .= "    osm_id, ";
-            $sSQL .= "    place_id, ";
-            $sSQL .= "    housenumber_for_place, ";
-            $sSQL .= "    country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
-            if (!$this->bDeDupe) $sSQL .= ", place_id ";
+            $sSQL .= "FROM location_postcode lp";
+            $sSQL .= " WHERE place_id in ($sPlaceIDs) ";
 
-            if (CONST_Use_Aux_Location_data) {
-                $sSQL .= " UNION ";
-                $sSQL .= "  SELECT ";
-                $sSQL .= "     'L' AS osm_type, ";
-                $sSQL .= "     place_id AS osm_id, ";
-                $sSQL .= "     'place' AS class,";
-                $sSQL .= "     'house' AS type, ";
-                $sSQL .= "     null AS admin_level, ";
-                $sSQL .= "     0 AS rank_search,";
-                $sSQL .= "     0 AS rank_address, ";
-                $sSQL .= "     min(place_id) AS place_id,";
-                $sSQL .= "     min(parent_place_id) AS parent_place_id, ";
-                $sSQL .= "     'us' AS country_code, ";
-                $sSQL .= "     get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress, ";
-                $sSQL .= "     null AS placename, ";
-                $sSQL .= "     null AS ref, ";
+            $aSubSelects[] = $sSQL;
+        }
+
+        // All other tables are rank 30 only.
+        if ($this->iMaxAddressRank == 30) {
+            // TIGER table
+            if (CONST_Use_US_Tiger_Data) {
+                $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_TIGER);
+                if ($sPlaceIDs) {
+                    $sHousenumbers = Result::sqlHouseNumberTable($aResults, Result::TABLE_TIGER);
+                    // Tiger search only if a housenumber was searched and if it was found
+                    // (realized through a join)
+                    $sSQL = " SELECT ";
+                    $sSQL .= "     'T' AS osm_type, ";
+                    $sSQL .= "     (SELECT osm_id from placex p WHERE p.place_id=min(blub.parent_place_id)) as osm_id, ";
+                    $sSQL .= "     'place' AS class, ";
+                    $sSQL .= "     'house' AS type, ";
+                    $sSQL .= "     null AS admin_level, ";
+                    $sSQL .= "     30 AS rank_search, ";
+                    $sSQL .= "     30 AS rank_address, ";
+                    $sSQL .= "     min(place_id) AS place_id, ";
+                    $sSQL .= "     min(parent_place_id) AS parent_place_id, ";
+                    $sSQL .= "     'us' AS country_code, ";
+                    $sSQL .= "     get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) AS langaddress,";
+                    $sSQL .= "     null AS placename, ";
+                    $sSQL .= "     null AS ref, ";
+                    if ($this->bIncludeExtraTags) $sSQL .= "null AS extra,";
+                    if ($this->bIncludeNameDetails) $sSQL .= "null AS names,";
+                    $sSQL .= "     avg(st_x(centroid)) AS lon, ";
+                    $sSQL .= "     avg(st_y(centroid)) AS lat,";
+                    $sSQL .= "     -1.15".$sImportanceSQL." AS importance, ";
+                    if ($oCtx->hasNearPoint()) {
+                        $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
+                    } else {
+                        $sSQL .= "     (";
+                        $sSQL .= "        SELECT max(p.importance*(p.rank_address+2))";
+                        $sSQL .= "        FROM ";
+                        $sSQL .= "          place_addressline s, ";
+                        $sSQL .= "          placex p";
+                        $sSQL .= "        WHERE s.place_id = min(blub.parent_place_id)";
+                        $sSQL .= "          AND p.place_id = s.address_place_id ";
+                        $sSQL .= "          AND s.isaddress";
+                        $sSQL .= "          AND p.importance is not null";
+                        $sSQL .= "     ) AS addressimportance, ";
+                    }
+                    $sSQL .= "     null AS extra_place ";
+                    $sSQL .= " FROM (";
+                    $sSQL .= "     SELECT place_id, ";    // interpolate the Tiger housenumbers here
+                    $sSQL .= "         ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) AS centroid, ";
+                    $sSQL .= "         parent_place_id, ";
+                    $sSQL .= "         housenumber_for_place";
+                    $sSQL .= "     FROM (";
+                    $sSQL .= "            location_property_tiger ";
+                    $sSQL .= "            JOIN (values ".$sHousenumbers.") AS housenumbers(place_id, housenumber_for_place) USING(place_id)) ";
+                    $sSQL .= "     WHERE ";
+                    $sSQL .= "         housenumber_for_place >= startnumber";
+                    $sSQL .= "         AND housenumber_for_place <= endnumber";
+                    $sSQL .= " ) AS blub"; //postgres wants an alias here
+                    $sSQL .= " GROUP BY";
+                    $sSQL .= "      place_id, ";
+                    $sSQL .= "      housenumber_for_place"; //is this group by really needed?, place_id + housenumber (in combination) are unique
+                    if (!$this->bDeDupe) $sSQL .= ", place_id ";
+
+                    $aSubSelects[] = $sSQL;
+                }
+            }
+
+            // osmline - interpolated housenumbers
+            $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_OSMLINE);
+            if ($sPlaceIDs) {
+                $sHousenumbers = Result::sqlHouseNumberTable($aResults, Result::TABLE_OSMLINE);
+                // interpolation line search only if a housenumber was searched
+                // (realized through a join)
+                $sSQL = "SELECT ";
+                $sSQL .= "  'W' AS osm_type, ";
+                $sSQL .= "  osm_id, ";
+                $sSQL .= "  'place' AS class, ";
+                $sSQL .= "  'house' AS type, ";
+                $sSQL .= "  null AS admin_level, ";
+                $sSQL .= "  30 AS rank_search, ";
+                $sSQL .= "  30 AS rank_address, ";
+                $sSQL .= "  min(place_id) as place_id, ";
+                $sSQL .= "  min(parent_place_id) AS parent_place_id, ";
+                $sSQL .= "  country_code, ";
+                $sSQL .= "  get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) AS langaddress, ";
+                $sSQL .= "  null AS placename, ";
+                $sSQL .= "  null AS ref, ";
                 if ($this->bIncludeExtraTags) $sSQL .= "null AS extra, ";
                 if ($this->bIncludeNameDetails) $sSQL .= "null AS names, ";
-                $sSQL .= "     avg(ST_X(centroid)) AS lon, ";
-                $sSQL .= "     avg(ST_Y(centroid)) AS lat, ";
-                $sSQL .= "     -1.10".$sImportanceSQL." AS importance, ";
+                $sSQL .= "  AVG(st_x(centroid)) AS lon, ";
+                $sSQL .= "  AVG(st_y(centroid)) AS lat, ";
+                $sSQL .= "  -0.1".$sImportanceSQL." AS importance, ";  // slightly smaller than the importance for normal houses with rank 30, which is 0
                 if ($oCtx->hasNearPoint()) {
                     $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
                 } else {
-                    $sSQL .= "     ( ";
-                    $sSQL .= "       SELECT max(p.importance*(p.rank_address+2))";
-                    $sSQL .= "       FROM ";
-                    $sSQL .= "          place_addressline s, ";
-                    $sSQL .= "          placex p";
-                    $sSQL .= "       WHERE s.place_id = min(location_property_aux.parent_place_id)";
-                    $sSQL .= "         AND p.place_id = s.address_place_id ";
-                    $sSQL .= "         AND s.isaddress";
-                    $sSQL .= "         AND p.importance is not null";
-                    $sSQL .= "     ) AS addressimportance, ";
+                    $sSQL .= "  (";
+                    $sSQL .= "     SELECT ";
+                    $sSQL .= "       MAX(p.importance*(p.rank_address+2)) ";
+                    $sSQL .= "     FROM";
+                    $sSQL .= "       place_addressline s, ";
+                    $sSQL .= "       placex p";
+                    $sSQL .= "     WHERE s.place_id = min(blub.parent_place_id) ";
+                    $sSQL .= "       AND p.place_id = s.address_place_id ";
+                    $sSQL .= "       AND s.isaddress ";
+                    $sSQL .= "       AND p.importance is not null";
+                    $sSQL .= "  ) AS addressimportance,";
                 }
-                $sSQL .= "     null AS extra_place ";
-                $sSQL .= "  FROM location_property_aux ";
-                $sSQL .= "  WHERE place_id in ($sPlaceIDs) ";
-                $sSQL .= "    AND 30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
+                $sSQL .= "  null AS extra_place ";
+                $sSQL .= "  FROM (";
+                $sSQL .= "     SELECT ";
+                $sSQL .= "         osm_id, ";
+                $sSQL .= "         place_id, ";
+                $sSQL .= "         country_code, ";
+                $sSQL .= "         CASE ";             // interpolate the housenumbers here
+                $sSQL .= "           WHEN startnumber != endnumber ";
+                $sSQL .= "           THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
+                $sSQL .= "           ELSE ST_LineInterpolatePoint(linegeo, 0.5) ";
+                $sSQL .= "         END as centroid, ";
+                $sSQL .= "         parent_place_id, ";
+                $sSQL .= "         housenumber_for_place ";
+                $sSQL .= "     FROM (";
+                $sSQL .= "            location_property_osmline ";
+                $sSQL .= "            JOIN (values ".$sHousenumbers.") AS housenumbers(place_id, housenumber_for_place) USING(place_id)";
+                $sSQL .= "          ) ";
+                $sSQL .= "     WHERE housenumber_for_place>=0 ";
+                $sSQL .= "       AND 30 between $this->iMinAddressRank AND $this->iMaxAddressRank";
+                $sSQL .= "  ) as blub"; //postgres wants an alias here
                 $sSQL .= "  GROUP BY ";
-                $sSQL .= "     place_id, ";
-                if (!$this->bDeDupe) $sSQL .= "place_id, ";
-                $sSQL .= "     get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) ";
+                $sSQL .= "    osm_id, ";
+                $sSQL .= "    place_id, ";
+                $sSQL .= "    housenumber_for_place, ";
+                $sSQL .= "    country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
+                if (!$this->bDeDupe) $sSQL .= ", place_id ";
+
+                $aSubSelects[] = $sSQL;
+            }
+
+            if (CONST_Use_Aux_Location_data) {
+                $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_AUX);
+                if ($sPlaceIDs) {
+                    $sHousenumbers = Result::sqlHouseNumberTable($aResults, Result::TABLE_AUX);
+                    $sSQL = "  SELECT ";
+                    $sSQL .= "     'L' AS osm_type, ";
+                    $sSQL .= "     place_id AS osm_id, ";
+                    $sSQL .= "     'place' AS class,";
+                    $sSQL .= "     'house' AS type, ";
+                    $sSQL .= "     null AS admin_level, ";
+                    $sSQL .= "     0 AS rank_search,";
+                    $sSQL .= "     0 AS rank_address, ";
+                    $sSQL .= "     min(place_id) AS place_id,";
+                    $sSQL .= "     min(parent_place_id) AS parent_place_id, ";
+                    $sSQL .= "     'us' AS country_code, ";
+                    $sSQL .= "     get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) AS langaddress, ";
+                    $sSQL .= "     null AS placename, ";
+                    $sSQL .= "     null AS ref, ";
+                    if ($this->bIncludeExtraTags) $sSQL .= "null AS extra, ";
+                    if ($this->bIncludeNameDetails) $sSQL .= "null AS names, ";
+                    $sSQL .= "     avg(ST_X(centroid)) AS lon, ";
+                    $sSQL .= "     avg(ST_Y(centroid)) AS lat, ";
+                    $sSQL .= "     -1.10".$sImportanceSQL." AS importance, ";
+                    if ($oCtx->hasNearPoint()) {
+                        $sSQL .= $oCtx->distanceSQL('ST_Collect(centroid)')." AS addressimportance,";
+                    } else {
+                        $sSQL .= "     ( ";
+                        $sSQL .= "       SELECT max(p.importance*(p.rank_address+2))";
+                        $sSQL .= "       FROM ";
+                        $sSQL .= "          place_addressline s, ";
+                        $sSQL .= "          placex p";
+                        $sSQL .= "       WHERE s.place_id = min(location_property_aux.parent_place_id)";
+                        $sSQL .= "         AND p.place_id = s.address_place_id ";
+                        $sSQL .= "         AND s.isaddress";
+                        $sSQL .= "         AND p.importance is not null";
+                        $sSQL .= "     ) AS addressimportance, ";
+                    }
+                    $sSQL .= "     null AS extra_place ";
+                    $sSQL .= "  FROM location_property_aux ";
+                    $sSQL .= "  WHERE place_id in ($sPlaceIDs) ";
+                    $sSQL .= "    AND 30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
+                    $sSQL .= "  GROUP BY ";
+                    $sSQL .= "     place_id, ";
+                    if (!$this->bDeDupe) $sSQL .= "place_id, ";
+                    $sSQL .= "     langaddress ";
+
+                    $aSubSelects[] = $sSQL;
+                }
             }
         }
 
-        $sSQL .= " order by importance desc";
+        if (!sizeof($aSubSelects)) {
+            return array();
+        }
+
+        $sSQL = join(' UNION ', $aSubSelects)." order by importance desc";
         if (CONST_Debug) {
             echo "<hr>";
             var_dump($sSQL);
@@ -1088,8 +1109,7 @@ class Geocode
             if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
 
             // Start the search process
-            // array with: placeid => -1 | tiger-housenumber
-            $aResultPlaceIDs = array();
+            $aResults = array();
             $iGroupLoop = 0;
             $iQueryLoop = 0;
             foreach ($aGroupedSearches as $iGroupedRank => $aSearches) {
@@ -1102,74 +1122,76 @@ class Geocode
                         _debugDumpGroupedSearches(array($iGroupedRank => array($oSearch)), $aValidTokens);
                     }
 
-                    $aRes = $oSearch->query(
+                    $aResults += $oSearch->query(
                         $this->oDB,
                         $aWordFrequencyScores,
-                        $this->exactMatchCache,
                         $this->iMinAddressRank,
                         $this->iMaxAddressRank,
                         $this->iLimit
                     );
 
-                    foreach ($aRes['IDs'] as $iPlaceID) {
-                        // array for placeID => -1 | Tiger housenumber
-                        $aResultPlaceIDs[$iPlaceID] = $aRes['houseNumber'];
-                    }
                     if ($iQueryLoop > 20) break;
                 }
 
-                if (sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30)) {
+                if (sizeof($aResults) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30)) {
                     // Need to verify passes rank limits before dropping out of the loop (yuk!)
                     // reduces the number of place ids, like a filter
                     // rank_address is 30 for interpolated housenumbers
-                    $sWherePlaceId = 'WHERE place_id in (';
-                    $sWherePlaceId .= join(',', array_keys($aResultPlaceIDs)).') ';
+                    $aFilterSql = array();
+                    $sPlaceIds = Result::joinIdsByTable($aResults, Result::TABLE_PLACEX);
+                    if ($sPlaceIds) {
+                        $sSQL = 'SELECT place_id FROM placex ';
+                        $sSQL .= 'WHERE place_id in ('.$sPlaceIds.') ';
+                        $sSQL .= "  AND (";
+                        $sSQL .= "         placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
+                        if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) {
+                            $sSQL .= "     OR (extratags->'place') = 'city'";
+                        }
+                        if ($this->aAddressRankList) {
+                            $sSQL .= "     OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
+                        }
+                        $sSQL .= ")";
+                        $aFilterSql[] = $sSQL;
+                    }
+                    $sPlaceIds = Result::joinIdsByTable($aResults, Result::TABLE_POSTCODE);
+                    if ($sPlaceIds) {
+                        $sSQL = ' SELECT place_id FROM location_postcode lp ';
+                        $sSQL .= 'WHERE place_id in ('.$sPlaceIds.') ';
+                        $sSQL .= "  AND (lp.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
+                        if ($this->aAddressRankList) {
+                            $sSQL .= "     OR lp.rank_address in (".join(',', $this->aAddressRankList).")";
+                        }
+                        $sSQL .= ") ";
+                        $aFilterSql[] = $sSQL;
+                    }
 
-                    $sSQL = "SELECT place_id ";
-                    $sSQL .= "FROM placex ".$sWherePlaceId;
-                    $sSQL .= "  AND (";
-                    $sSQL .= "         placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-                    if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) {
-                        $sSQL .= "     OR (extratags->'place') = 'city'";
+                    $aFilteredIDs = array();
+                    if ($aFilterSql) {
+                        $sSQL = join(' UNION ', $aFilterSql);
+                        if (CONST_Debug) var_dump($sSQL);
+                        $aFilteredIDs = chksql($this->oDB->getCol($sSQL));
                     }
-                    if ($this->aAddressRankList) {
-                        $sSQL .= "     OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
-                    }
-                    $sSQL .= "  ) UNION ";
-                    $sSQL .= " SELECT place_id FROM location_postcode lp ".$sWherePlaceId;
-                    $sSQL .= "  AND (lp.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-                    if ($this->aAddressRankList) {
-                        $sSQL .= "     OR lp.rank_address in (".join(',', $this->aAddressRankList).")";
-                    }
-                    $sSQL .= ") ";
-                    if (CONST_Use_US_Tiger_Data && $this->iMaxAddressRank == 30) {
-                        $sSQL .= "UNION ";
-                        $sSQL .= "  SELECT place_id ";
-                        $sSQL .= "  FROM location_property_tiger ".$sWherePlaceId;
-                    }
-                    if ($this->iMaxAddressRank == 30) {
-                        $sSQL .= "UNION ";
-                        $sSQL .= "  SELECT place_id ";
-                        $sSQL .= "  FROM location_property_osmline ".$sWherePlaceId;
-                    }
-                    if (CONST_Debug) var_dump($sSQL);
-                    $aFilteredPlaceIDs = chksql($this->oDB->getCol($sSQL));
+
                     $tempIDs = array();
-                    foreach ($aFilteredPlaceIDs as $placeID) {
-                        $tempIDs[$placeID] = $aResultPlaceIDs[$placeID];  //assign housenumber to placeID
+                    foreach ($aResults as $oResult) {
+                        if (($this->iMaxAddressRank == 30 &&
+                             ($oResult->iTable == Result::TABLE_OSMLINE
+                              || $oResult->iTable == Result::TABLE_AUX
+                              || $oResult->iTable == Result::TABLE_TIGER))
+                            || in_array($oResult->iId, $aFilteredIDs)
+                        ) {
+                            $tempIDs[$oResult->iId] = $oResult;
+                        }
                     }
-                    $aResultPlaceIDs = $tempIDs;
+                    $aResults = $tempIDs;
                 }
 
-                if (sizeof($aResultPlaceIDs)) break;
+                if (sizeof($aResults)) break;
                 if ($iGroupLoop > 4) break;
                 if ($iQueryLoop > 30) break;
             }
 
-            // Did we find anything?
-            if (sizeof($aResultPlaceIDs)) {
-                $aSearchResults = $this->getDetails($aResultPlaceIDs, $oCtx);
-            }
+            $aSearchResults = $this->getDetails($aResults, $oCtx);
         } else {
             // Just interpret as a reverse geocode
             $oReverse = new ReverseGeocode($this->oDB);
@@ -1180,8 +1202,8 @@ class Geocode
             if (CONST_Debug) var_dump("Reverse search", $aLookup);
 
             if ($aLookup['place_id']) {
-                $aSearchResults = $this->getDetails(array($aLookup['place_id'] => -1), $oCtx);
-                $aResultPlaceIDs[$aLookup['place_id']] = -1;
+                $aResults = array($aLookup['place_id'] => new Result($aLookup['place_id']));
+                $aSearchResults = $this->getDetails($aResults, $oCtx);
             } else {
                 $aSearchResults = array();
             }
@@ -1251,7 +1273,7 @@ class Geocode
             // if tag '&addressdetails=1' is set in query
             if ($this->bIncludeAddressDetails) {
                 // getAddressDetails() is defined in lib.php and uses the SQL function get_addressdata in functions.sql
-                $aResult['address'] = getAddressDetails($this->oDB, $sLanguagePrefArraySQL, $aResult['place_id'], $aResult['country_code'], $aResultPlaceIDs[$aResult['place_id']]);
+                $aResult['address'] = getAddressDetails($this->oDB, $sLanguagePrefArraySQL, $aResult['place_id'], $aResult['country_code'], $aResults[$aResult['place_id']]->iHouseNumber);
                 if ($aResult['extra_place'] == 'city' && !isset($aResult['address']['city'])) {
                     $aResult['address'] = array_merge(array('city' => array_values($aResult['address'])[0]), $aResult['address']);
                 }
@@ -1296,11 +1318,7 @@ class Geocode
                 // - approximate importance of address parts
                 $aResult['foundorder'] = -$aResult['addressimportance']/10;
                 // - number of exact matches from the query
-                if (isset($this->exactMatchCache[$aResult['place_id']])) {
-                    $aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
-                } elseif (isset($this->exactMatchCache[$aResult['parent_place_id']])) {
-                    $aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
-                }
+                $aResult['foundorder'] -= $aResults[$aResult['place_id']]->iExactMatches;
                 // - importance of the class/type
                 if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
                     && $aClassType[$aResult['class'].':'.$aResult['type']]['importance']

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1197,12 +1197,12 @@ class Geocode
             $oReverse = new ReverseGeocode($this->oDB);
             $oReverse->setZoom(18);
 
-            $aLookup = $oReverse->lookupPoint($oCtx->sqlNear, false);
+            $oLookup = $oReverse->lookupPoint($oCtx->sqlNear, false);
 
             if (CONST_Debug) var_dump("Reverse search", $aLookup);
 
-            if ($aLookup['place_id']) {
-                $aResults = array($aLookup['place_id'] => new Result($aLookup['place_id']));
+            if ($oLookup) {
+                $aResults = array($oLookup->iId => $oLookup);
                 $aSearchResults = $this->getDetails($aResults, $oCtx);
             } else {
                 $aSearchResults = array();

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -173,7 +173,7 @@ class PlaceLookup
             $sSQL .= '    avg(ST_Y(centroid)) AS lat, ';
             $sSQL .= '    COALESCE(importance,0.75-(rank_search::float/40)) AS importance, ';
             $sSQL .= $this->addressImportanceSql(
-                'centroid',
+                'ST_Collect(centroid)',
                 'min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END)'
             );
             $sSQL .= "    (extratags->'place') AS extra_place ";
@@ -388,6 +388,7 @@ class PlaceLookup
             "Could not lookup place"
         );
 
+        $aClassType = getClassTypes();
         foreach ($aPlaces as &$aPlace) {
             if ($this->bAddressDetails) {
                 // to get addressdetails for tiger data, the housenumber is needed
@@ -413,7 +414,6 @@ class PlaceLookup
                 }
             }
 
-            $aClassType = getClassTypes();
             $sAddressType = '';
             $sClassType = $aPlace['class'].':'.$aPlace['type'].':'.$aPlace['admin_level'];
             if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel'])) {

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -133,17 +133,16 @@ class PlaceLookup
             return null;
         }
 
-        return $this->lookup(new Result($iPlaceID));
+        $aResults = $this->lookup(array($iPlaceID => new Result($iPlaceID)));
+
+        return sizeof($aResults) ? reset($aResults) : null;
     }
 
-    public function lookup($oResult, $iMinRank = 0, $iMaxRank = 30)
+    public function lookup($aResults, $iMinRank = 0, $iMaxRank = 30)
     {
-        if ($oResult === null) {
-            return null;
+        if (!sizeof($aResults)) {
+            return array();
         }
-
-        $aResults = array($oResult->iId => $oResult);
-
         $aSubSelects = array();
 
         $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_PLACEX);
@@ -381,19 +380,13 @@ class PlaceLookup
         if (CONST_Debug) var_dump($aSubSelects);
 
         if (!sizeof($aSubSelects)) {
-            return null;
+            return array();
         }
 
         $aPlaces = chksql(
             $this->oDB->getAll(join(' UNION ', $aSubSelects)),
             "Could not lookup place"
         );
-
-        if (!sizeof($aPlaces)) {
-            return null;
-        }
-
-        if (CONST_Debug) var_dump($aPlaces);
 
         foreach ($aPlaces as &$aPlace) {
             if ($this->bAddressDetails) {
@@ -437,7 +430,7 @@ class PlaceLookup
 
         if (CONST_Debug) var_dump($aPlaces);
 
-        return reset($aPlaces);
+        return $aPlaces;
     }
 
     private function getAddressDetails($iPlaceID, $bAll, $sHousenumber)

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -2,6 +2,8 @@
 
 namespace Nominatim;
 
+require_once(CONST_BasePath.'/lib/Result.php');
+
 class PlaceLookup
 {
     protected $oDB;
@@ -75,54 +77,58 @@ class PlaceLookup
         $this->fPolygonSimplificationThreshold = $f;
     }
 
-    public function lookupOSMID($sType, $iID)
+    private function languagePrefSql()
     {
-        $sSQL = "select place_id from placex where osm_type = '".pg_escape_string($sType)."' and osm_id = ".(int)$iID." order by type = 'postcode' asc";
-        $iPlaceID = chksql($this->oDB->getOne($sSQL));
-
-        return $this->lookup((int)$iPlaceID);
+        return 'ARRAY['.join(',', array_map('getDBQuoted', $this->aLangPrefOrder)).']';
     }
 
-    public function lookup($iPlaceID, $sType = '', $fInterpolFraction = 0.0)
+    public function lookupOSMID($sType, $iID)
     {
-        if (!$iPlaceID) return null;
+        $sSQL = "select place_id from placex where osm_type = '".$sType."' and osm_id = ".$iID;
+        $iPlaceID = chksql($this->oDB->getOne($sSQL));
 
-        $sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
-        $bIsTiger = CONST_Use_US_Tiger_Data && $sType == 'tiger';
-        $bIsInterpolation = $sType == 'interpolation';
+        if (!$iPlaceID) {
+            return null;
+        }
 
-        if ($bIsTiger) {
-            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, postcode,";
+        return $this->lookup(new Result($iPlaceID));
+    }
+
+    public function lookup($oResult)
+    {
+        if ($oResult === null) {
+            return null;
+        }
+
+        $sLanguagePrefArraySQL = $this->languagePrefSql();
+        $iPlaceID = $oResult->iId;
+
+        if ($oResult->iTable == Result::TABLE_TIGER) {
+            $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level,";
+            $sSQL .= $oResult->iHouseNumber.' as housenumber, postcode,';
             $sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
             $sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as country_code, ";
-            $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
+            $sSQL .= " get_address_by_language(place_id,".$oResult->iHouseNumber.", $sLanguagePrefArraySQL) as langaddress,";
             $sSQL .= " null as placename,";
             $sSQL .= " null as ref,";
             if ($this->bExtraTags) $sSQL .= " null as extra,";
             if ($this->bNameDetails) $sSQL .= " null as names,";
-            $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
-            $sSQL .= " (select *, ";
-            $sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-            $sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-            $sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-            $sSQL .= " END as housenumber";
-            $sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
-        } elseif ($bIsInterpolation) {
-            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, postcode,";
+            $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat";
+            $sSQL .= " FROM (select *, ST_LineInterpolatePoint(linegeo, (".$oResult->iHouseNumber."-startnumber::float)/(endnumber-startnumber)::float) as point ";
+            $sSQL .= " FROM location_property_tiger where place_id = ".$iPlaceID.") as blub";
+        } elseif ($oResult->iTable == Result::TABLE_OSMLINE) {
+            $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level,";
+            $sSQL .= $oResult->iHouseNumber.' as housenumber, postcode,';
             $sSQL .= " country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
             $sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, country_code, ";
-            $sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
+            $sSQL .= " get_address_by_language(place_id,".$oResult->iHouseNumber.", $sLanguagePrefArraySQL) as langaddress,";
             $sSQL .= " null as placename,";
             $sSQL .= " null as ref,";
             if ($this->bExtraTags) $sSQL .= " null as extra,";
             if ($this->bNameDetails) $sSQL .= " null as names,";
-            $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
-            $sSQL .= " (select *, ";
-            $sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-            $sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-            $sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-            $sSQL .= " END as housenumber";
-            $sSQL .= " from location_property_osmline where place_id = ".$iPlaceID.") as blub1) as blub2";
+            $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat ";
+            $sSQL .= " FROM (select *, ST_LineInterpolatePoint(linegeo, (".$oResult->iHouseNumber."-startnumber::float)/(endnumber-startnumber)::float) as point ";
+            $sSQL .= " from location_property_osmline where place_id = ".$iPlaceID.") as blub";
             // testcase: interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
             // but this will never happen, because if the searched point is that close to the endnumber, the endnumber house will be directly taken from placex (in ReverseGeocode.php line 220)
             // and not interpolated
@@ -147,8 +153,7 @@ class PlaceLookup
 
         if ($this->bAddressDetails) {
             // to get addressdetails for tiger data, the housenumber is needed
-            $iHousenumber = ($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1;
-            $aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'], $iHousenumber);
+            $aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'], $oResult->iHouseNumber);
         }
 
         if ($this->bExtraTags) {

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -32,6 +32,36 @@ class PlaceLookup
         $this->oDB =& $oDB;
     }
 
+    public function loadParamArray($oParams)
+    {
+        $aLangs = $oParams->getPreferredLanguages();
+        $this->aLangPrefOrderSql =
+            'ARRAY['.join(',', array_map('getDBQuoted', $aLangs)).']';
+
+        $this->bExtraTags = $oParams->getBool('extratags', false);
+        $this->bNameDetails = $oParams->getBool('namedetails', false);
+
+        $this->bIncludePolygonAsText = $oParams->getBool('polygon_text');
+        $this->bIncludePolygonAsGeoJSON = $oParams->getBool('polygon_geojson');
+        $this->bIncludePolygonAsKML = $oParams->getBool('polygon_kml');
+        $this->bIncludePolygonAsSVG = $oParams->getBool('polygon_svg');
+        $this->fPolygonSimplificationThreshold
+            = $oParams->getFloat('polygon_threshold', 0.0);
+
+        $iWantedTypes =
+            ($this->bIncludePolygonAsText ? 1 : 0) +
+            ($this->bIncludePolygonAsGeoJSON ? 1 : 0) +
+            ($this->bIncludePolygonAsKML ? 1 : 0) +
+            ($this->bIncludePolygonAsSVG ? 1 : 0);
+        if ($iWantedTypes > CONST_PolygonOutput_MaximumTypes) {
+            if (CONST_PolygonOutput_MaximumTypes) {
+                userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
+            } else {
+                userError("Polygon output is disabled");
+            }
+        }
+    }
+
     public function setAnchorSql($sPoint)
     {
         $this->sAnchorSql = $sPoint;

--- a/lib/Result.php
+++ b/lib/Result.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Nominatim;
+
+/**
+ * A single result of a search operation or a reverse lookup.
+ *
+ * This object only contains the id of the result. It does not yet
+ * have any details needed to format the output document.
+ */
+class Result
+{
+    const TABLE_PLACEX = 0;
+    const TABLE_POSTCODE = 1;
+    const TABLE_OSMLINE = 2;
+    const TABLE_AUX = 3;
+    const TABLE_TIGER = 4;
+
+    /// Database table that contains the result.
+    public $iTable;
+    /// Id of the result.
+    public $iId;
+    /// House number (only for interpolation results).
+    public $iHouseNumber = -1;
+    /// Number of exact matches in address (address searches only).
+    public $iExactMatches = 0;
+    /// Subranking within the results (the higher the worse).
+    public $iResultRank = 0;
+
+
+    public function __construct($sId, $iTable = Result::TABLE_PLACEX)
+    {
+        $this->iTable = $iTable;
+        $this->iId = (int) $sId;
+    }
+
+    public static function joinIdsByTable($aResults, $iTable)
+    {
+        return join(',', array_keys(array_filter(
+            $aResults,
+            function ($aValue) use ($iTable) {
+                return $aValue->iTable == $iTable;
+            }
+        )));
+    }
+    public static function sqlHouseNumberTable($aResults, $iTable)
+    {
+        $sHousenumbers = '';
+        $sSep = '';
+        foreach ($aResults as $oResult) {
+            if ($oResult->iTable == $iTable) {
+                $sHousenumbers .= $sSep.'('.$oResult->iId.',';
+                $sHousenumbers .= $oResult->iHouseNumber.')';
+                $sSep = ',';
+            }
+        }
+
+        return $sHousenumbers;
+    }
+}

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -615,3 +615,23 @@ function createPointsAroundCenter($fLon, $fLat, $fRadius)
     }
     return $aPolyPoints;
 }
+
+function closestHouseNumber($aRow)
+{
+    $fHouse = $aRow['startnumber']
+                + ($aRow['endnumber'] - $aRow['startnumber']) * $aRow['fraction'];
+
+    switch ($aRow['interpolationtype']) {
+        case 'odd':
+            $iHn = (int)($fHouse/2) * 2 + 1;
+            break;
+        case 'even':
+            $iHn = (int)(round($fHouse/2)) * 2;
+            break;
+        default:
+            $iHn = (int)(round($fHouse));
+            break;
+    }
+
+    return max(min($aRow['endnumber'], $iHn), $aRow['startnumber']);
+}

--- a/test/bdd/api/search/simple.feature
+++ b/test/bdd/api/search/simple.feature
@@ -102,7 +102,7 @@ Feature: Simple Tests
     Scenario: Empty XML search with viewbox
         When sending xml search query "xnznxvcx"
           | viewbox |
-          | 12,45.13,77,33 |
+          | 12,33,77,45.13 |
         Then result header contains
           | attr        | value |
           | querystring | xnznxvcx |
@@ -117,12 +117,12 @@ Feature: Simple Tests
           | attr        | value |
           | querystring | xnznxvcx |
           | polygon     | false |
-          | viewbox     | 12,45,77,34.13 |
+          | viewbox     | 12,34.13,77,45 |
 
     Scenario: Empty XML search with viewboxlbrt and viewbox
         When sending xml search query "pub"
           | viewbox        | viewboxblrt |
-          | 12,45.13,77,33 | 1,2,3,4 |
+          | 12,33,77,45.13 | 1,2,3,4 |
         Then result header contains
           | attr        | value |
           | querystring | pub |

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -24,10 +24,7 @@ $aSearchResults = array();
 $aCleanedQueryParts = array();
 
 $oPlaceLookup = new Nominatim\PlaceLookup($oDB);
-$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-$oPlaceLookup->setIncludeAddressDetails($oParams->getBool('addressdetails', true));
-$oPlaceLookup->setIncludeExtraTags($oParams->getBool('extratags', false));
-$oPlaceLookup->setIncludeNameDetails($oParams->getBool('namedetails', false));
+$oPlaceLookup->loadParamArray($oParams);
 
 $aOsmIds = explode(',', $oParams->getString('osm_ids', ''));
 

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -59,7 +59,12 @@ if ($sOsmType && $iOsmId > 0) {
     $oLookup = $oReverseGeocode->lookup($fLat, $fLon);
     if (CONST_Debug) var_dump($oLookup);
 
-    $aPlace = $oPlaceLookup->lookup($oLookup);
+    if ($oLookup) {
+        $aPlaces = $oPlaceLookup->lookup(array($oLookup->iId => $oLookup));
+        if (sizeof($aPlaces)) {
+            $aPlace = reset($aPlaces);
+        }
+    }
 } elseif ($sOutputFormat != 'html') {
     userError("Need coordinates or OSM object to lookup.");
 }

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -23,7 +23,6 @@ $hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
 $oPlaceLookup = new Nominatim\PlaceLookup($oDB);
 $oPlaceLookup->loadParamArray($oParams);
-$oPlaceLookup->setIncludeAddressDetails($oParams->getBool('addressdetails', true));
 
 $sOsmType = $oParams->getSet('osm_type', array('N', 'W', 'R'));
 $iOsmId = $oParams->getInt('osm_id', -1);

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -11,23 +11,6 @@ ini_set('memory_limit', '200M');
 
 $oParams = new Nominatim\ParameterParser();
 
-$bAsGeoJSON = $oParams->getBool('polygon_geojson');
-$bAsKML = $oParams->getBool('polygon_kml');
-$bAsSVG = $oParams->getBool('polygon_svg');
-$bAsText = $oParams->getBool('polygon_text');
-
-$iWantedTypes = ($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0) + ($bAsText?1:0);
-if ($iWantedTypes > CONST_PolygonOutput_MaximumTypes) {
-    if (CONST_PolygonOutput_MaximumTypes) {
-        userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-    } else {
-        userError("Polygon output is disabled");
-    }
-}
-
-// Polygon simplification threshold (optional)
-$fThreshold = $oParams->getFloat('polygon_threshold', 0.0);
-
 // Format for output
 $sOutputFormat = $oParams->getSet('format', array('html', 'xml', 'json', 'jsonv2'), 'xml');
 
@@ -38,23 +21,21 @@ $oDB =& getDB();
 
 $hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
-
 $oPlaceLookup = new Nominatim\PlaceLookup($oDB);
-$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
+$oPlaceLookup->loadParamArray($oParams);
 $oPlaceLookup->setIncludeAddressDetails($oParams->getBool('addressdetails', true));
-$oPlaceLookup->setIncludeExtraTags($oParams->getBool('extratags', false));
-$oPlaceLookup->setIncludeNameDetails($oParams->getBool('namedetails', false));
 
 $sOsmType = $oParams->getSet('osm_type', array('N', 'W', 'R'));
 $iOsmId = $oParams->getInt('osm_id', -1);
 $fLat = $oParams->getFloat('lat');
 $fLon = $oParams->getFloat('lon');
-$iZoom = $oParams->getInt('zoom');
+$iZoom = $oParams->getInt('zoom', 18);
+
 if ($sOsmType && $iOsmId > 0) {
     $aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
 } elseif ($fLat !== false && $fLon !== false) {
     $oReverseGeocode = new Nominatim\ReverseGeocode($oDB);
-    $oReverseGeocode->setZoom($iZoom !== false ? $iZoom : 18);
+    $oReverseGeocode->setZoom($iZoom);
 
     $oLookup = $oReverseGeocode->lookup($fLat, $fLon);
     if (CONST_Debug) var_dump($oLookup);
@@ -70,13 +51,6 @@ if ($sOsmType && $iOsmId > 0) {
 }
 
 if (isset($aPlace)) {
-    $oPlaceLookup->setIncludePolygonAsPoints(false);
-    $oPlaceLookup->setIncludePolygonAsText($bAsText);
-    $oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
-    $oPlaceLookup->setIncludePolygonAsKML($bAsKML);
-    $oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
-    $oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
-
     $fRadius = $fDiameter = getResultDiameter($aPlace);
     $aOutlineResult = $oPlaceLookup->getOutlines(
         $aPlace['place_id'],

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -56,14 +56,10 @@ if ($sOsmType && $iOsmId > 0) {
     $oReverseGeocode = new Nominatim\ReverseGeocode($oDB);
     $oReverseGeocode->setZoom($iZoom !== false ? $iZoom : 18);
 
-    $aLookup = $oReverseGeocode->lookup($fLat, $fLon);
-    if (CONST_Debug) var_dump($aLookup);
+    $oLookup = $oReverseGeocode->lookup($fLat, $fLon);
+    if (CONST_Debug) var_dump($oLookup);
 
-    $aPlace = $oPlaceLookup->lookup(
-        (int)$aLookup['place_id'],
-        $aLookup['type'],
-        $aLookup['fraction']
-    );
+    $aPlace = $oPlaceLookup->lookup($oLookup);
 } elseif ($sOutputFormat != 'html') {
     userError("Need coordinates or OSM object to lookup.");
 }

--- a/website/search.php
+++ b/website/search.php
@@ -28,36 +28,8 @@ if (CONST_Search_ReversePlanForAll
 // Format for output
 $sOutputFormat = $oParams->getSet('format', array('html', 'xml', 'json', 'jsonv2'), 'html');
 
-// Show / use polygons
-if ($sOutputFormat == 'html') {
-    $oGeocode->setIncludePolygonAsGeoJSON($oParams->getBool('polygon_geojson'));
-    $bAsGeoJSON = false;
-} else {
-    $bAsPoints = $oParams->getBool('polygon');
-    $bAsGeoJSON = $oParams->getBool('polygon_geojson');
-    $bAsKML = $oParams->getBool('polygon_kml');
-    $bAsSVG = $oParams->getBool('polygon_svg');
-    $bAsText = $oParams->getBool('polygon_text');
-    $iWantedTypes = ($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0) + ($bAsText?1:0) + ($bAsPoints?1:0);
-    if ($iWantedTypes > CONST_PolygonOutput_MaximumTypes) {
-        if (CONST_PolygonOutput_MaximumTypes) {
-            userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-        } else {
-            userError("Polygon output is disabled");
-        }
-        exit;
-    }
-    $oGeocode->setIncludePolygonAsPoints($bAsPoints);
-    $oGeocode->setIncludePolygonAsText($bAsText);
-    $oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
-    $oGeocode->setIncludePolygonAsKML($bAsKML);
-    $oGeocode->setIncludePolygonAsSVG($bAsSVG);
-}
-
-// Polygon simplification threshold (optional)
-$oGeocode->setPolygonSimplificationThreshold($oParams->getFloat('polygon_threshold', 0.0));
-
-$oGeocode->loadParamArray($oParams);
+$sForcedGeometry = ($sOutputFormat == 'html') ? "geojson" : null;
+$oGeocode->loadParamArray($oParams, $sForcedGeometry);
 
 if (CONST_Search_BatchMode && isset($_GET['batch'])) {
     $aBatch = json_decode($_GET['batch'], true);


### PR DESCRIPTION
Introduces a new class Result which contains search results without details, i.e. place_id and (optionally) housenumber. This class can later be used to also store how well a result has matched the search creteria.

Moves the SQL code for place details lookup from Geocode::get_details() into PlaceLookup::lookup(), so that PlaceLookup now also can look up multiple results in parallel in different tables. ReverseGeocode::lookup() now returns an array with a single result, so that it presents the same interface as Geocode().

Finally adds a loadParamArray() method to PlaceLookup, which sets the class members according to the HTTP query parameters. With this change, Geocode and ReverseGeocode no longer need to know about the parameters. That allows to remove a lot of boiler plate code.

ReverseGeocode also sees some functional changes. The queries are slightly reworked so that the additional query for the distance of the place is no longer necessary.