### PR TITLE
Add function to recalculate counts for full-word search term

### DIFF
--- a/docs/Import-and-Update.md
+++ b/docs/Import-and-Update.md
@@ -68,6 +68,17 @@ import, for excerpts you can use less. Adapt to your available RAM to
 avoid swapping, never give more than 2/3 of RAM to osm2pgsql.
 
 
+Computing word frequency for search terms can improve the performance of
+forward geocoding in particular under high load as it helps Postgres' query
+planner to make the right decisions. To recompute word counts run:
+
+    ./utils/update.php --recompute-word-counts
+
+This will take a couple of hours for a full planet installation. You can
+also defer that step to a later point in time when you realise that
+performance becomes an issue. Just make sure that updates are stopped before
+running this function.
+
 Loading additional datasets
 ---------------------------
 

--- a/sql/words_from_search_name.sql
+++ b/sql/words_from_search_name.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS word_frequencies;
+CREATE TABLE word_frequencies AS
+ SELECT unnest(name_vector) as id, count(*) FROM search_name GROUP BY id;
+
+CREATE INDEX idx_word_frequencies ON word_frequencies(id);
+
+UPDATE word SET search_name_count = count
+  FROM word_frequencies
+ WHERE word_token like ' %' and word_id = id;
+
+DROP TABLE word_frequencies;

--- a/utils/update.php
+++ b/utils/update.php
@@ -33,6 +33,7 @@ $aCMDOptions
    array('index-instances', '', 0, 1, 1, 1, 'int', 'Number of indexing instances (threads)'),
 
    array('deduplicate', '', 0, 1, 0, 0, 'bool', 'Deduplicate tokens'),
+   array('recompute-word-counts', '', 0, 1, 0, 0, 'bool', 'Compute frequency of full-word search terms'),
    array('no-npi', '', 0, 1, 0, 0, 'bool', '(obsolete)'),
   );
 getCmdOpt($_SERVER['argv'], $aCMDOptions, $aResult, true, true);
@@ -235,6 +236,12 @@ if ($aResult['deduplicate']) {
             chksql($oDB->query($sSQL));
         }
     }
+}
+
+if ($aResult['recompute-word-counts']) {
+    info('Recompute frequency of full-word search terms');
+    $sTemplate = file_get_contents(CONST_BasePath.'/sql/words_from_search_name.sql');
+    runSQLScript($sTemplate, true, true);
 }
 
 if ($aResult['index']) {


### PR DESCRIPTION
Calculating counts for full-word search terms helps to improve performance of search queries tremendously. On nominatim.osm.org the Postgres' IO throughput was reduced by something like 60%. Problem is that the calculation is quite expensive, so I don't want to make it a mandatory part of the installation process.