### PR TITLE
Add function to check if new updates are available

### DIFF
--- a/utils/check_server_for_updates.py
+++ b/utils/check_server_for_updates.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+import sys
+from osmium.replication import server
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: python check_server_for_updates.py <server url> <sequence id>")
+        sys.exit(254)
+
+    seqid = int(sys.argv[2])
+
+    state = server.ReplicationServer(sys.argv[1]).get_state_info()
+
+    if state is None:
+        print("ERROR: Cannot get state from URL %s." % (sys.argv[1], ))
+        sys.exit(253)
+
+    if state.sequence <= seqid:
+        print("Database up to date.")
+        sys.exit(1)
+
+    print("New data available (%i => %i)." % (seqid, state.sequence))
+    sys.exit(0)

--- a/utils/update.php
+++ b/utils/update.php
@@ -13,6 +13,7 @@ $aCMDOptions
    array('verbose', 'v', 0, 1, 0, 0, 'bool', 'Verbose output'),
 
    array('init-updates', '', 0, 1, 0, 0, 'bool', 'Set up database for updating'),
+   array('check-for-updates', '', 0, 1, 0, 0, 'bool', 'Check if new updates are available'),
    array('import-osmosis', '', 0, 1, 0, 0, 'bool', 'Import updates once'),
    array('import-osmosis-all', '', 0, 1, 0, 0, 'bool', 'Import updates forever'),
    array('no-index', '', 0, 1, 0, 0, 'bool', 'Do not index the new data'),
@@ -96,6 +97,17 @@ if ($aResult['init-updates']) {
     }
 
     echo "Done. Database updates will start at sequence $aOutput[0] ($sWindBack)\n";
+}
+
+if ($aResult['check-for-updates']) {
+    $aLastState = chksql($oDB->getRow('SELECT sequence_id FROM import_status'));
+
+    if (!$aLastState['sequence_id']) {
+        fail('Updates not set up. Please run ./utils/update.php --init-updates.');
+    }
+
+    system(CONST_BasePath.'/utils/check_server_for_updates.py '.CONST_Replication_Url.' '.$aLastState['sequence_id'], $iRet);
+    exit($iRet);
 }
 
 if (isset($aResult['import-diff']) || isset($aResult['import-file'])) {


### PR DESCRIPTION
Running `./utils/update.php --check-for-updates` quickly checks if new data is available for download. Returns 0 if new data is available, 1 if everything is up-to-date and other error codes if something else went wrong.