### PR TITLE
shorten line to please PHP style guide

### DIFF
--- a/utils/update.php
+++ b/utils/update.php
@@ -263,7 +263,8 @@ if ($aResult['index']) {
 if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
     //
     if (strpos(CONST_Replication_Url, 'download.geofabrik.de') !== false && CONST_Replication_Update_Interval < 86400) {
-        fail("Error: Update interval too low for download.geofabrik.de.  Please check install documentation (http://nominatim.org/release-docs/latest/Import-and-Update#setting-up-the-update-process)\n");
+        fail('Error: Update interval too low for download.geofabrik.de. ' .
+             "Please check install documentation (http://nominatim.org/release-docs/latest/Import-and-Update#setting-up-the-update-process)\n");
     }
 
     $sImportFile = CONST_InstallPath.'/osmosischange.osc';


### PR DESCRIPTION
fixes
```
 266 | ERROR | Line exceeds maximum limit of 194 characters; contains 203 characters
```
error in PHPCS.