### PR TITLE
PlaceLookup::getAddressDetails() should be public

### DIFF
--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -462,7 +462,7 @@ class PlaceLookup
         return $aPlaces;
     }
 
-    private function getAddressDetails($iPlaceID, $bAll, $sHousenumber)
+    public function getAddressDetails($iPlaceID, $bAll = false, $sHousenumber = -1)
     {
         $sSQL = 'SELECT *,';
         $sSQL .= '  get_name_by_language(name,'.$this->aLangPrefOrderSql.') as localname';


### PR DESCRIPTION
`PlaceLookup::getAddressDetails()` is also used within the hierarchy.php file so it must not be private.

Currently the `hierarchy.php` file aborts with a HTTP 500 error, because PHP is trying to access a private method. Also it passes only one argument so I restored the default values.

Both was changed here https://github.com/openstreetmap/Nominatim/commit/5eb11800a7fb0e3c35b72c1e1a6b643e78156750#diff-60bd0986b5cdf7c153f9005ac3d7123cL192 but I don't know why.