### PR TITLE
upgrade vagrant setup to centos 7.4, postgres 9.5, postgis 2.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
   end
 
    config.vm.define "centos" do |sub|
-      sub.vm.box = "bento/centos-7.2"
+      sub.vm.box = "bento/centos-7.4"
       sub.vm.provision :shell do |s|
         s.path = "vagrant/Install-on-Centos-7.sh"
         s.privileged = false

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -20,8 +20,10 @@
 # Now you can install all packages needed for Nominatim:
 
 #DOCS:    :::sh
-    sudo yum install -y postgresql-server postgresql-contrib postgresql-devel \
-                        postgis postgis-utils \
+    sudo rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-2.noarch.rpm
+
+    sudo yum install -y postgresql95-server postgresql95-contrib postgresql95-devel \
+                        postgis24_95 postgis24_95-utils \
                         git cmake make gcc gcc-c++ libtool policycoreutils-python \
                         php-pgsql php php-pear php-pear-DB php-intl libpqxx-devel \
                         proj-epsg bzip2-devel proj-devel libxml2-devel boost-devel \
@@ -71,11 +73,17 @@
 # Setting up PostgreSQL
 # ---------------------
 #
+# Make sure cnake finds pg_config in $PATH
+
+    echo 'pathmunge /usr/pgsql-9.5/bin' | sudo tee -a /etc/profile.d/postgresql95.sh
+    sudo chmod +x /etc/profile.d/postgresql95.sh
+    source /etc/profile
+
 # CentOS does not automatically create a database cluster. Therefore, start
 # with initializing the database, then enable the server to start at boot:
 
-    sudo postgresql-setup initdb
-    sudo systemctl enable postgresql
+    sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb
+    sudo systemctl enable postgresql-9.5.service
 
 #
 # Next tune the postgresql configuration, which is located in 
@@ -85,7 +93,7 @@
 #
 # Now start the postgresql service after updating this config file.
 
-    sudo systemctl restart postgresql
+    sudo systemctl restart postgresql-9.5
 
 #
 # Finally, we need to add two postgres users: one for the user that does


### PR DESCRIPTION
related to https://github.com/openstreetmap/Nominatim/issues/932

Nominatim requires postgresql > 9.2 so I upgraded the vagrant installation files, which in turn are used to generate our install documentation.

Tested with CentOS 7.2 and 7.4. I imported Monaco and forward geocoding worked.

Using the full path in `sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb` is necessary because `source /etc/profile` doesn't seem to reload sudo's environment.