### PR TITLE
move CentOS Vagrant VM to a SELinux-enabled base image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,39 +32,21 @@ Vagrant.configure("2") do |config|
       end
   end
 
-   config.vm.define "centos" do |sub|
+  config.vm.define "centos" do |sub|
       sub.vm.box = "centos/7"
       sub.vm.provision :shell do |s|
         s.path = "vagrant/Install-on-Centos-7.sh"
         s.privileged = false
         s.args = "yes"
-        sub.vm.synced_folder ".", "/vagrant", disabled: true
       end
+      sub.vm.synced_folder ".", "/home/vagrant/Nominatim", disabled: true
+      sub.vm.synced_folder ".", "/vagrant", disabled: true
   end
-
-  # configure shared package cache if possible
-  #if Vagrant.has_plugin?("vagrant-cachier")
-  #  config.cache.enable :apt
-  #  config.cache.scope = :box
-  #end
-
 
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.memory = 2048
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//vagrant","0"]
   end
-
-
-  # config.vm.provider :digital_ocean do |provider, override|
-  #   override.ssh.private_key_path = '~/.ssh/id_rsa'
-  #   override.vm.box = 'digital_ocean'
-  #   override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
-
-  #   provider.token = ''
-  #   # provider.token = 'YOUR TOKEN'
-  #   provider.image = 'ubuntu-14-04-x64'
-  #   provider.region = 'nyc2'
-  #   provider.size = '512mb'
-  # end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,8 @@ Vagrant.configure("2") do |config|
       sub.vm.provision :shell do |s|
         s.path = "vagrant/Install-on-Centos-7.sh"
         s.privileged = false
-        s.args = [checkout]
+        s.args = "yes"
+        sub.vm.synced_folder ".", "/vagrant", disabled: true
       end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
   end
 
    config.vm.define "centos" do |sub|
-      sub.vm.box = "bento/centos-7.2"
+      sub.vm.box = "centos/7"
       sub.vm.provision :shell do |s|
         s.path = "vagrant/Install-on-Centos-7.sh"
         s.privileged = false

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -52,8 +52,8 @@
 # we assume this user is called nominatim and the installation will be in
 # /srv/nominatim. To create the user and directory run:
 #
-sudo mkdir -p /opt/nominatim       #DOCS:    sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
-sudo chown vagrant /opt/nominatim  #DOCS:
+sudo mkdir -p /srv/nominatim       #DOCS:    sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
+sudo chown vagrant /srv/nominatim  #DOCS:
 #
 # You may find a more suitable location if you wish.
 #
@@ -61,7 +61,7 @@ sudo chown vagrant /opt/nominatim  #DOCS:
 # user name and home directory now like this:
 #
     export USERNAME=vagrant        #DOCS:    export USERNAME=nominatim
-    export USERHOME=/opt/nominatim #DOCS:    export USERHOME=/srv/nominatim
+    export USERHOME=/srv/nominatim
 #
 # **Never, ever run the installation as a root user.** You have been warned.
 #
@@ -126,17 +126,6 @@ sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
     sudo systemctl enable httpd
     sudo systemctl restart httpd
 
-#
-# Adding SELinux Security Settings
-# --------------------------------
-#
-# It is a good idea to leave SELinux enabled and enforcing, particularly
-# with a web server accessible from the Internet. At a minimum the
-# following SELinux labeling should be done for Nominatim:
-
-    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/Nominatim/(website|lib|settings)(/.*)?"
-    sudo semanage fcontext -a -t lib_t "$USERHOME/build/module/nominatim.so"
-    sudo restorecon -R -v $USERHOME/Nominatim
 
 #
 # Installing Nominatim
@@ -170,6 +159,21 @@ fi                                 #DOCS:
     cd build
     cmake $USERHOME/Nominatim
     make
+
+#
+# Adding SELinux Security Settings
+# --------------------------------
+#
+# It is a good idea to leave SELinux enabled and enforcing, particularly
+# with a web server accessible from the Internet. At a minimum the
+# following SELinux labeling should be done for Nominatim:
+
+    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/Nominatim/(website|lib|settings)(/.*)?"
+    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/build/(website|lib|settings)(/.*)?"
+    sudo semanage fcontext -a -t lib_t "$USERHOME/build/module/nominatim.so"
+    sudo restorecon -R -v $USERHOME/Nominatim
+    sudo restorecon -R -v $USERHOME/build
+
 
 # You need to create a minimal configuration file that tells nominatim
 # the name of your webserver user and the URL of the website:

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -22,7 +22,7 @@
 #DOCS:    :::sh
     sudo yum install -y postgresql-server postgresql-contrib postgresql-devel \
                         postgis postgis-utils \
-                        git cmake make gcc gcc-c++ libtool policycoreutils-python \
+                        wget git cmake make gcc gcc-c++ libtool policycoreutils-python \
                         php-pgsql php php-pear php-pear-DB php-intl libpqxx-devel \
                         proj-epsg bzip2-devel proj-devel libxml2-devel boost-devel \
                         expat-devel zlib-devel
@@ -52,7 +52,8 @@
 # we assume this user is called nominatim and the installation will be in
 # /srv/nominatim. To create the user and directory run:
 #
-#     sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
+sudo mkdir -p /opt/nominatim       #DOCS:    sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
+sudo chown vagrant /opt/nominatim  #DOCS:
 #
 # You may find a more suitable location if you wish.
 #
@@ -60,7 +61,7 @@
 # user name and home directory now like this:
 #
     export USERNAME=vagrant        #DOCS:    export USERNAME=nominatim
-    export USERHOME=/home/vagrant  #DOCS:    export USERHOME=/srv/nominatim
+    export USERHOME=/opt/nominatim #DOCS:    export USERHOME=/srv/nominatim
 #
 # **Never, ever run the installation as a root user.** You have been warned.
 #
@@ -122,6 +123,7 @@ sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
 # Then reload apache
 #
 
+    sudo systemctl enable httpd
     sudo systemctl restart httpd
 
 #
@@ -133,7 +135,7 @@ sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
 # following SELinux labeling should be done for Nominatim:
 
     sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/Nominatim/(website|lib|settings)(/.*)?"
-    sudo semanage fcontext -a -t lib_t "$USERHOME/Nominatim/module/nominatim.so"
+    sudo semanage fcontext -a -t lib_t "$USERHOME/build/module/nominatim.so"
     sudo restorecon -R -v $USERHOME/Nominatim
 
 #

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -106,14 +106,14 @@ sudo chown vagrant /srv/nominatim  #DOCS:
 
 #DOCS:```sh
 sudo tee /etc/httpd/conf.d/nominatim.conf << EOFAPACHECONF
-<Directory "$USERHOME/build/website"> #DOCS:<Directory "$USERHOME/Nominatim/build/website">
+<Directory "$USERHOME/build/website"> #DOCS:<Directory "$USERHOME/build/website">
   Options FollowSymLinks MultiViews
   AddType text/html   .php
   DirectoryIndex search.php
   Require all granted
 </Directory>
 
-Alias /nominatim $USERHOME/build/website  #DOCS:Alias /nominatim $USERHOME/Nominatim/build/website
+Alias /nominatim $USERHOME/build/website  #DOCS:Alias /nominatim $USERHOME/build/website
 EOFAPACHECONF
 #DOCS:```
 


### PR DESCRIPTION
Setup finishes fine. Later (see `Vagrant.md`) importing Monaco works and we can fetch results with `curl`.

Surprisingly SELinux doesn't allow `.so` files in user directories. In `/src/nominatim` doesn't work either. `/opt/nominatim` works.

This base image doesn't have the VirtualBox Guest Additions (https://gist.github.com/fernandoaleman/5083680) installed, thus `/home/vagrant/Nominatim` isn't symlinked to the source (host). During `vagrant up` Vagrant rsyncs the host's Nominatim directory into `/vagrant` on the host once.

Needs to be started using `CHECKOUT=y vagrant up centos` though I wonder if we could simply check for the existence of a `/vagrant` directory.