### PR TITLE
enable 3 spacing rules again, no PHP file needed changes

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -86,19 +86,6 @@
        INDENTATION, SPACING
        ************************************************************** -->
 
-  <!-- We don't need 2 blank lines after function -->
-  <rule ref="Squiz.WhiteSpace.FunctionSpacing.After">
-    <severity>0</severity>
-  </rule>
-
-  <!-- Aligned looks nicer, but causes too many warnings currently -->
-  <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSame">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSameWarning">
-    <severity>0</severity>
-  </rule>
-
   <!-- Aligned looks nicer, but causes too many warnings currently -->
   <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
     <severity>0</severity>


### PR DESCRIPTION
We used to disable three styling rules because they caused too many warnings. When enabled it turns out all our PHP code follows the rules already (in other words no warnings).