### PR TITLE
update Vagrant instructions. E.g. cucumber => behave

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -19,7 +19,7 @@ is.
 
         git clone --recursive https://github.com/openstreetmap/Nominatim.git
 
-    If forgot `--recursive`, you can later load the submodules using
+    If you forgot `--recursive`, it you can later load the submodules using
     
         git submodule init
         git submodule update
@@ -62,8 +62,9 @@ You edit code on your host machine in any editor you like. There is no need to
 restart any software: just refresh your browser window.
 
 Note that the webserver uses files from the /build directory. If you change
-files in Nominatim/lib for example you first need to copy them into the
-/build directory.
+files in Nominatim/website or Nominatim/utils for example you first need to
+copy them into the /build directory by running the `cmake` step from the
+installation.
 
 PHP errors are written to `/var/log/apache2/error.log`.
 
@@ -103,8 +104,12 @@ To run the full test suite
 To run a single file
 
     behave -DBUILDDIR=/home/vagrant/build/ features/api/reverse.feature
+
+Or a single test by line number
+
+    behave -DBUILDDIR=/home/vagrant/build/ features/api/reverse.feature:34
     
-To run specific tests you can add tags just before the `Scenario line`, e.g.
+To run specific groups of tests you can add tags just before the `Scenario line`, e.g.
 
     @bug-34
     Scenario: address lookup for non-existing or invalid node, way, relation

--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -1,11 +1,11 @@
 # Install Nominatim in a virtual machine for development and testing
 
-This document describes how you can install Nominatim inside a Ubuntu 14
+This document describes how you can install Nominatim inside a Ubuntu 16
 virtual machine on your desktop/laptop (host machine). The goal is to give
 you a development environment to easily edit code and run the test suite
 without affecting the rest of your system. 
 
-The installation can run largely unsupervised. You should expect 1-2h from
+The installation can run largely unsupervised. You should expect 1h from
 start to finish depending on how fast your computer and download speed
 is.
 
@@ -19,7 +19,7 @@ is.
 
         git clone --recursive https://github.com/openstreetmap/Nominatim.git
 
-    If you haven't used `--recursive`, then you can load the submodules using
+    If forgot `--recursive`, you can later load the submodules using
     
         git submodule init
         git submodule update
@@ -37,18 +37,14 @@ is.
         vagrant ssh ubuntu
 
 3. Import a small country (Monaco)
-
-    You need to give the virtual machine more memory (2GB) for an import,
-    see `Vagrantfile`. Otherwise 1GB is enough.
     
     See the FAQ how to skip this step and point Nominatim to an existing database.
 
       ```
       # inside the virtual machine:
-      mkdir data
       cd build
-      wget --no-verbose --output-document=../data/monaco.osm.pbf http://download.geofabrik.de/europe/monaco-latest.osm.pbf
-      ./utils/setup.php --osm-file ../data/monaco.osm.pbf --osm2pgsql-cache 1000 --all 2>&1 | tee monaco.$$.log
+      wget --no-verbose --output-document=/tmp/monaco.osm.pbf http://download.geofabrik.de/europe/monaco-latest.osm.pbf
+      ./utils/setup.php --osm-file /tmp/monaco.osm.pbf --osm2pgsql-cache 1000 --all 2>&1 | tee monaco.$$.log
       ```
 
     To repeat an import you'd need to delete the database first
@@ -65,13 +61,31 @@ see Nominatim in action on [locahost:8089](http://localhost:8089/nominatim/).
 You edit code on your host machine in any editor you like. There is no need to
 restart any software: just refresh your browser window.
 
+Note that the webserver uses files from the /build directory. If you change
+files in Nominatim/lib for example you first need to copy them into the
+/build directory.
+
 PHP errors are written to `/var/log/apache2/error.log`.
 
 With `echo` and `var_dump()` you write into the output (HTML/XML/JSON) when
 you either add `&debug=1` to the URL (preferred) or set
 `@define('CONST_Debug', true);` in `settings/local.php`.
 
+In the Python BDD test you can use `logger.info()` for temporary debug
+statements.
 
+
+
+## Running unit tests
+
+    cd ~/Nominatim/tests/php
+    phpunit ./
+
+
+## Running PHP code style tests
+
+    cd ~/Nominatim
+    phpcs --colors .
 
 
 ## Running functional tests
@@ -83,12 +97,12 @@ installation to cause false positives in the other tests (see FAQ).
 
 To run the full test suite
 
-    cd ~/Nominatim/tests
-    NOMINATIM_SERVER=http://localhost:8089/nominatim lettuce features
+    cd ~/Nominatim/test/bdd
+    behave -DBUILDDIR=/home/vagrant/build/ db osm2pgsql
 
 To run a single file
 
-    NOMINATIM_SERVER=http://localhost:8089/nominatim lettuce features/api/reverse.feature
+    behave -DBUILDDIR=/home/vagrant/build/ features/api/reverse.feature
     
 To run specific tests you can add tags just before the `Scenario line`, e.g.
 
@@ -97,13 +111,7 @@ To run specific tests you can add tags just before the `Scenario line`, e.g.
 
 and then
 
-    NOMINATIM_SERVER=http://localhost:8089/nominatim lettuce -t bug-34
-
-
-## Running unit tests
-
-    cd ~/Nominatim/tests/php
-    phpunit ./
+    behave -DBUILDDIR=/home/vagrant/build/ --tags @bug-34
 
 
 
@@ -130,17 +138,18 @@ bug fixes) get added since those usually only get applied to new/changed data.
 Also this document skips the optional Wikipedia data import which affects ranking
 of search results. See [Nominatim installation](http://nominatim.org/release-docs/latest/Installation) for details.
 
-##### Why Ubuntu and CentOS, can I test CentOS/CoreOS/FreeBSD?
+##### Why Ubuntu? Can I test CentOS/Fedora/CoreOS/FreeBSD?
 
-There is a Vagrant script for CentOS available. Simply start your box
-with `vagrant up centos` and then log in with `vagrant ssh centos`.
-In general Nominatim will also run in the other environments. The installation steps
+There is a Vagrant script for CentOS available, but the Nominatim directory
+isn't symlinked/mounted to the host which makes development trickier. We used
+it mainly for debugging installation with SELinux.
+
+In general Nominatim will run in the other environments. The installation steps
 are slightly different, e.g. the name of the package manager, Apache2 package
 name, location of files. We chose Ubuntu because that is closest to the
 nominatim.openstreetmap.org production environment.
 
-You can configure/download other Vagrant boxes from [vagrantbox.es](http://www.vagrantbox.es/).
-
+You can configure/download other Vagrant boxes from [https://app.vagrantup.com/boxes/search](https://app.vagrantup.com/boxes/search).
 
 ##### How can I connect to an existing database?
 
@@ -148,7 +157,7 @@ Let's say you have a Postgres database named `nominatim_it` on server `your-serv
 
     pgsql://postgres@your-server.com:5432/nominatim_it
     
-No data import necessary, no restarting necessary.
+No data import necessary or restarting necessary.
 
 If the Postgres installation is behind a firewall, you can try
 
@@ -157,14 +166,15 @@ If the Postgres installation is behind a firewall, you can try
 inside the virtual machine. It will map the port to `localhost:9999` and then
 you edit `settings/local.php` with
 
-    pgsql://postgres@localhost:9999/nominatim_it
+    @define('CONST_Database_DSN', 'pgsql://postgres@localhost:9999/nominatim_it');
 
 To access postgres directly remember to specify the hostname, e.g. `psql --host localhost --port 9999 nominatim_it`
 
 
 ##### My computer is slow and the import takes too long. Can I start the virtual machine "in the cloud"?
 
-Yes. It's possible to start the virtual machine on [Amazon AWS (plugin)](https://github.com/mitchellh/vagrant-aws) or [DigitalOcean (plugin)](https://github.com/smdahlen/vagrant-digitalocean).
+Yes. It's possible to start the virtual machine on [Amazon AWS (plugin)](https://github.com/mitchellh/vagrant-aws)
+or [DigitalOcean (plugin)](https://github.com/smdahlen/vagrant-digitalocean).
 
 
 


### PR DESCRIPTION
* documentation still pointed to cucumber tests
* we no longer recommend centos for Vagrant development
* we use Ubuntu 16 in Vagrant, not 14