### PR TITLE
remove the 2-minute offset hack from data date in HTML output

### DIFF
--- a/website/details.php
+++ b/website/details.php
@@ -231,7 +231,7 @@ if ($oParams->getBool('keywords')) {
 logEnd($oDB, $hLog, 1);
 
 if ($sOutputFormat=='html') {
-    $sSQL = "SELECT TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' FROM import_status LIMIT 1";
+    $sSQL = "SELECT TO_CHAR(lastimportdate,'YYYY/MM/DD HH24:MI')||' GMT' FROM import_status LIMIT 1";
     $sDataDate = chksql($oDB->getOne($sSQL));
     $sTileURL = CONST_Map_Tile_URL;
     $sTileAttribution = CONST_Map_Tile_Attribution;

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -72,7 +72,7 @@ if (CONST_Debug) {
 }
 
 if ($sOutputFormat == 'html') {
-    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
     $sTileURL = CONST_Map_Tile_URL;
     $sTileAttribution = CONST_Map_Tile_Attribution;
 }

--- a/website/search.php
+++ b/website/search.php
@@ -66,7 +66,7 @@ $hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
 $aSearchResults = $oGeocode->lookup();
 
 if ($sOutputFormat=='html') {
-    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
 }
 logEnd($oDB, $hLog, sizeof($aSearchResults));
 


### PR DESCRIPTION
As noted in https://github.com/openstreetmap/Nominatim/pull/949

    We probably should get rid of the 2 min hack as well at this point. The factor is there because the 
    data from the last update step might not have been indexed yet and therefore cannot be found. 
    However, indexing can take arbitrarily long so there is no telling how far back the last update step 
    was completed.
