### PR TITLE
NominatimTest.php => LibTest.php

### DIFF
--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -4,15 +4,8 @@ namespace Nominatim;
 
 require_once '../../lib/lib.php';
 
-class NominatimTest extends \PHPUnit_Framework_TestCase
+class LibTest extends \PHPUnit_Framework_TestCase
 {
-
-
-    protected function setUp()
-    {
-    }
-
-
     public function testGetClassTypesWithImportance()
     {
         $aClasses = getClassTypesWithImportance();


### PR DESCRIPTION
Trivial rename. `NominatimTest` was the first PHP test file, instead it should reflect that only functions in `lib/lib.php` are tested.