### PR TITLE
phpcs: remove trailing whitespace from comments

### DIFF
--- a/settings/phrase_settings.php
+++ b/settings/phrase_settings.php
@@ -9,7 +9,7 @@ $aTagsBlacklist
     'place' => array('house', 'houses'),
    );
 
-// If a class is in the white list then all types will 
+// If a class is in the white list then all types will
 // be ignored except the ones given in the list.
 // Also use this list to exclude an entire class from
 // special phrases.

--- a/utils/importWikipedia.php
+++ b/utils/importWikipedia.php
@@ -37,7 +37,7 @@ $sTestPageText = <<<EOD
 | coasters = 12
 | water_rides = 2
 | owner = [[Six Flags]]
-| general_manager = 
+| general_manager =
 | homepage = [http://www.sixflags.com/parks/greatadventure/ Six Flags Great Adventure]
 }}
 EOD;


### PR DESCRIPTION
Trivial whitespace change. The phpcs in my vagrant seems to test more, thus two errors, than what we have in the travis environment.