### PR TITLE
Immenbusch BDD failed after ranking returns a place in France first

### DIFF
--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -11,6 +11,8 @@ Feature: Search queries
           | house_number | 2 |
           | hamlet       | Steinwald |
           | postcode     | 6811 |
+          | county       | Feldkirch |
+          | state        | Vorarlberg |
           | country      | Austria |
           | country_code | at |
 
@@ -122,7 +124,7 @@ Feature: Search queries
         Then exactly 0 results are returned
 
     Scenario: Arbitrary key/value search near a road
-        When sending json search query "[leisure=table_soccer_table] immenbusch"
+        When sending json search query "[leisure=table_soccer_table] immenbusch, germany"
         Then results contain
           | class   | type |
           | leisure | table_soccer_table |


### PR DESCRIPTION
Changed two API BDD tests because they fail against my planet installation. Checked against nominatim.osm.org output.

https://nominatim.openstreetmap.org/search.php?q=immenbusch returns a place in France on first position.

The Steinwald query indeed returns more components https://nominatim.openstreetmap.org/search.php?q=2+Steinwald%2C+Austria&format=jsonv2&addressdetails=1&pretty=1