### PR TITLE
add JSON format to /status endpoint

### DIFF
--- a/lib/Status.php
+++ b/lib/Status.php
@@ -9,39 +9,35 @@ class Status
 {
     protected $oDB;
 
-
     public function __construct(&$oDB)
     {
         $this->oDB =& $oDB;
     }
 
-    // return null on success
     public function status()
     {
         if (!$this->oDB || PEAR::isError($this->oDB)) {
-            return 'No database';
+            throw new Exception('No database', 700);
         }
 
         $sStandardWord = $this->oDB->getOne("SELECT make_standard_name('a')");
         if (PEAR::isError($sStandardWord)) {
-            return 'Module failed';
+            throw new Exception('Module failed', 701);
         }
 
         if ($sStandardWord != 'a') {
-            return 'Module call failed';
+            throw new Exception('Module call failed', 702);
         }
 
         $sSQL = 'SELECT word_id, word_token, word, class, type, country_code, ';
         $sSQL .= "operator, search_name_count FROM word WHERE word_token IN (' a')";
         $iWordID = $this->oDB->getOne($sSQL);
         if (PEAR::isError($iWordID)) {
-            return 'Query failed';
+            throw new Exception('Query failed', 703);
         }
         if (!$iWordID) {
-            return 'No value';
+            throw new Exception('No value', 704);
         }
-
-        return;
     }
 
     public function dataDate()
@@ -50,7 +46,7 @@ class Status
         $iDataDateEpoch = $this->oDB->getOne($sSQL);
 
         if (PEAR::isError($iDataDateEpoch)) {
-            throw Exception('Data date query failed '.$iDataDateEpoch->getMessage());
+            throw Exception('Data date query failed '.$iDataDateEpoch->getMessage(), 705);
         }
 
         return $iDataDateEpoch;

--- a/lib/Status.php
+++ b/lib/Status.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Nominatim;
+
+use Exception;
+use PEAR;
+
+class Status
+{
+    protected $oDB;
+
+
+    public function __construct(&$oDB)
+    {
+        $this->oDB =& $oDB;
+    }
+
+    // return null on success
+    public function status()
+    {
+        if (!$this->oDB || PEAR::isError($this->oDB)) {
+            return 'No database';
+        }
+
+        $sStandardWord = $this->oDB->getOne("SELECT make_standard_name('a')");
+        if (PEAR::isError($sStandardWord)) {
+            return 'Module failed';
+        }
+
+        if ($sStandardWord != 'a') {
+            return 'Module call failed';
+        }
+
+        $sSQL = 'SELECT word_id, word_token, word, class, type, country_code, ';
+        $sSQL .= "operator, search_name_count FROM word WHERE word_token IN (' a')";
+        $iWordID = $this->oDB->getOne($sSQL);
+        if (PEAR::isError($iWordID)) {
+            return 'Query failed';
+        }
+        if (!$iWordID) {
+            return 'No value';
+        }
+
+        return;
+    }
+
+    public function dataDate()
+    {
+        $sSQL = 'SELECT EXTRACT(EPOCH FROM lastimportdate) FROM import_status LIMIT 1';
+        $iDataDateEpoch = $this->oDB->getOne($sSQL);
+
+        if (PEAR::isError($iDataDateEpoch)) {
+            throw Exception('Data date query failed '.$iDataDateEpoch->getMessage());
+        }
+
+        return $iDataDateEpoch;
+    }
+}

--- a/test/bdd/api/status/failures.feature
+++ b/test/bdd/api/status/failures.feature
@@ -1,0 +1,17 @@
+@UNKNOWNDB
+Feature: Status queries against unknown database
+    Testing status query
+
+    Scenario: Failed status as text
+        When sending text status query
+        Then a HTTP 500 is returned
+        And the page contents equals "ERROR: No database"
+
+    Scenario: Failed status as json
+        When sending json status query
+        Then a HTTP 200 is returned
+        And the result is valid json
+        And results contain
+          | status | message |
+          | 700    | No database |
+        And result has not attributes data_updated

--- a/test/bdd/api/status/simple.feature
+++ b/test/bdd/api/status/simple.feature
@@ -27,5 +27,5 @@ Feature: Status queries
         And the result is valid json
         And results contain
           | status | message |
-          | 777    | An Error |
+          | 799    | An Error |
         And result has not attributes data_updated

--- a/test/bdd/api/status/simple.feature
+++ b/test/bdd/api/status/simple.feature
@@ -7,12 +7,6 @@ Feature: Status queries
         Then a HTTP 200 is returned
         And the page contents equals "OK"
 
-    Scenario: Failed status as text
-        When sending text status query demanding error
-        Then a HTTP 500 is returned
-        And the page contents equals "ERROR: An Error"
-
-
     Scenario: Status as json
         When sending json status query
         Then the result is valid json
@@ -20,12 +14,3 @@ Feature: Status queries
           | status | message |
           | 0      | OK      |
         And result has attributes data_updated
-
-    Scenario: Failed status as json
-        When sending json status query demanding error
-        Then a HTTP 200 is returned
-        And the result is valid json
-        And results contain
-          | status | message |
-          | 799    | An Error |
-        And result has not attributes data_updated

--- a/test/bdd/api/status/simple.feature
+++ b/test/bdd/api/status/simple.feature
@@ -1,0 +1,31 @@
+@APIDB
+Feature: Status queries
+    Testing status query
+
+    Scenario: Status as text
+        When sending status query
+        Then a HTTP 200 is returned
+        And the page contents equals "OK"
+
+    Scenario: Failed status as text
+        When sending text status query demanding error
+        Then a HTTP 500 is returned
+        And the page contents equals "ERROR: An Error"
+
+
+    Scenario: Status as json
+        When sending json status query
+        Then the result is valid json
+        And results contain
+          | status | message |
+          | 0      | OK      |
+        And result has attributes data_updated
+
+    Scenario: Failed status as json
+        When sending json status query demanding error
+        Then a HTTP 200 is returned
+        And the result is valid json
+        And results contain
+          | status | message |
+          | 777    | An Error |
+        And result has not attributes data_updated

--- a/test/bdd/environment.py
+++ b/test/bdd/environment.py
@@ -122,6 +122,9 @@ class NominatimEnvironment(object):
     def setup_api_db(self, context):
         self.write_nominatim_config(self.api_test_db)
 
+    def setup_unknown_db(self, context):
+        self.write_nominatim_config('UNKNOWN_DATABASE_NAME')
+
     def setup_db(self, context):
         self.setup_template_db()
         self.write_nominatim_config(self.test_db)
@@ -261,6 +264,8 @@ def before_scenario(context, scenario):
         context.nominatim.setup_db(context)
     elif 'APIDB' in context.tags:
         context.nominatim.setup_api_db(context)
+    elif 'UNKNOWNDB' in context.tags:
+        context.nominatim.setup_unknown_db(context)
     context.scene = None
 
 def after_scenario(context, scenario):

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -416,12 +416,9 @@ def website_lookup_request(context, fmt, query):
 
     context.response = SearchResponse(outp, outfmt, status)
 
-@when(u'sending (?P<fmt>\S+ )?status query\s*(?P<failing>demanding error)?')
-def website_status_request(context, fmt, failing):
+@when(u'sending (?P<fmt>\S+ )?status query')
+def website_status_request(context, fmt):
     params = {}
-    if failing is not None:
-        params['force_error'] = 1
-
     outp, status = send_api_query('status', params, fmt, context)
 
     if fmt is None:

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Nominatim;
+
+require_once('../../lib/Status.php');
+require_once('DB.php');
+
+class StatusTest extends \PHPUnit_Framework_TestCase
+{
+
+
+    public function testNoDatabaseConnectionFail()
+    {
+        // causes 'Non-static method should not be called statically, assuming $this from incompatible context'
+        // failure on travis
+        // $oDB = \DB::connect('', false); // returns a DB_Error instance
+
+        $oDB = new \DB_Error;
+        $oStatus = new Status($oDB);
+        $this->assertEquals('No database', $oStatus->status());
+
+        $oDB = null;
+        $oStatus = new Status($oDB);
+        $this->assertEquals('No database', $oStatus->status());
+    }
+
+
+    public function testModuleFail()
+    {
+        // stub has getOne method but doesn't return anything
+        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+
+        $oStatus = new Status($oDbStub);
+        $this->assertEquals('Module call failed', $oStatus->status());
+    }
+
+
+    public function testWordIdQueryFail()
+    {
+        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+
+        // return no word_id
+        $oDbStub->method('getOne')
+                ->will($this->returnCallback(function ($sql) {
+                    if (preg_match("/make_standard_name\('a'\)/", $sql)) return 'a';
+                    if (preg_match('/SELECT word_id, word_token/', $sql)) return null;
+                }));
+
+        $oStatus = new Status($oDbStub);
+        $this->assertEquals('No value', $oStatus->status());
+    }
+
+
+    public function testOK()
+    {
+        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+
+        $oDbStub->method('getOne')
+                ->will($this->returnCallback(function ($sql) {
+                    if (preg_match("/make_standard_name\('(\w+)'\)/", $sql, $aMatch)) return $aMatch[1];
+                    if (preg_match('/SELECT word_id, word_token/', $sql)) return 1234;
+                }));
+
+        $oStatus = new Status($oDbStub);
+        $this->assertNull($oStatus->status());
+    }
+
+    public function testDataDate()
+    {
+        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+     
+        $oDbStub->method('getOne')
+                ->willReturn(1519430221);
+
+        $oStatus = new Status($oDbStub);
+        $this->assertEquals(1519430221, $oStatus->dataDate());
+    }
+}

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -5,12 +5,16 @@ namespace Nominatim;
 require_once('../../lib/Status.php');
 require_once('DB.php');
 
+use Exception;
+
 class StatusTest extends \PHPUnit_Framework_TestCase
 {
 
 
     public function testNoDatabaseConnectionFail()
     {
+        $this->setExpectedException(Exception::class, 'No database', 700);
+
         // causes 'Non-static method should not be called statically, assuming $this from incompatible context'
         // failure on travis
         // $oDB = \DB::connect('', false); // returns a DB_Error instance
@@ -27,16 +31,20 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
     public function testModuleFail()
     {
+        $this->setExpectedException(Exception::class, 'Module call failed', 702);
+
         // stub has getOne method but doesn't return anything
         $oDbStub = $this->getMock(\DB::class, ['getOne']);
 
         $oStatus = new Status($oDbStub);
-        $this->assertEquals('Module call failed', $oStatus->status());
+        $this->assertNull($oStatus->status());
     }
 
 
     public function testWordIdQueryFail()
     {
+        $this->setExpectedException(Exception::class, 'No value', 704);
+
         $oDbStub = $this->getMock(\DB::class, ['getOne']);
 
         // return no word_id
@@ -47,7 +55,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
                 }));
 
         $oStatus = new Status($oDbStub);
-        $this->assertEquals('No value', $oStatus->status());
+        $this->assertNull($oStatus->status());
     }
 
 

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -11,6 +11,15 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 {
 
 
+    public function testNoDatabaseGiven()
+    {
+        $this->setExpectedException(Exception::class, 'No database', 700);
+
+        $oDB = null;
+        $oStatus = new Status($oDB);
+        $this->assertEquals('No database', $oStatus->status());
+    }
+
     public function testNoDatabaseConnectionFail()
     {
         $this->setExpectedException(Exception::class, 'No database', 700);

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -43,7 +43,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(Exception::class, 'Module call failed', 702);
 
         // stub has getOne method but doesn't return anything
-        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+        $oDbStub = $this->getMock(\DB::class, array('getOne'));
 
         $oStatus = new Status($oDbStub);
         $this->assertNull($oStatus->status());
@@ -54,7 +54,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(Exception::class, 'No value', 704);
 
-        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+        $oDbStub = $this->getMock(\DB::class, array('getOne'));
 
         // return no word_id
         $oDbStub->method('getOne')
@@ -70,7 +70,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
     public function testOK()
     {
-        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+        $oDbStub = $this->getMock(\DB::class, array('getOne'));
 
         $oDbStub->method('getOne')
                 ->will($this->returnCallback(function ($sql) {
@@ -84,7 +84,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
     public function testDataDate()
     {
-        $oDbStub = $this->getMock(\DB::class, ['getOne']);
+        $oDbStub = $this->getMock(\DB::class, array('getOne'));
      
         $oDbStub->method('getOne')
                 ->willReturn(1519430221);

--- a/website/status.php
+++ b/website/status.php
@@ -9,9 +9,8 @@ require_once(CONST_BasePath.'/lib/Status.php');
 
 $oParams = new Nominatim\ParameterParser();
 $sOutputFormat = $oParams->getSet('format', array('text', 'json'), 'text');
-$bForceError = $oParams->getInt('force_error', false);
 
-$oDB =& DB::connect(CONST_Database_DSN, false);
+$oDB = DB::connect(CONST_Database_DSN, false);
 $oStatus = new Nominatim\Status($oDB);
 
 
@@ -21,9 +20,6 @@ if ($sOutputFormat == 'json') {
 
 
 try {
-    if ($bForceError) {
-        throw new Exception('An Error', 799);
-    }
     $oStatus->status();
 } catch (Exception $oErr) {
     if ($sOutputFormat == 'json') {

--- a/website/status.php
+++ b/website/status.php
@@ -1,37 +1,61 @@
 <?php
+
 @define('CONST_ConnectionBucket_PageType', 'Status');
 
 require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
 require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/ParameterParser.php');
+require_once(CONST_BasePath.'/lib/Status.php');
+
+$oParams = new Nominatim\ParameterParser();
+$sOutputFormat = $oParams->getSet('format', array('text', 'json'), 'text');
+$bForceError = $oParams->getBool('force_error', false);
+
+$oDB =& DB::connect(CONST_Database_DSN, false);
+$oStatus = new Nominatim\Status($oDB);
 
 
-function statusError($sMsg)
-{
-    header('HTTP/1.0 500 Internal Server Error');
-    echo 'ERROR: '.$sMsg;
+$sErrorMsg = $oStatus->status(); // can be nil
+if ($bForceError) $sErrorMsg = 'An Error';
+
+
+if ($sOutputFormat == 'text') {
+    if ($sErrorMsg) {
+        header('HTTP/1.0 500 Internal Server Error');
+        echo 'ERROR: '.$sErrorMsg;
+    } else {
+        echo 'OK';
+    }
     exit;
 }
 
-$oDB =& DB::connect(CONST_Database_DSN, false);
-if (!$oDB || PEAR::isError($oDB)) {
-    statusError('No database');
+// JSON output
+
+$aResponse = array(
+              'status' => 0,
+              'message' => 'OK'
+             );
+
+if (!$sErrorMsg) {
+    try {
+        $aResponse['data_updated'] = (new DateTime('@'.$oStatus->dataDate()))->format(DateTime::RFC3339);
+    } catch (Exception $oErr) {
+        $sErrorMsg = $oErr->getMessage();
+    }
 }
 
-$sStandardWord = $oDB->getOne("select make_standard_name('a')");
-if (PEAR::isError($sStandardWord)) {
-    statusError('Module failed');
-}
-if ($sStandardWord != 'a') {
-    statusError('Module call failed');
+
+
+
+if ($sErrorMsg) {
+    $aResponse = array(
+                  'status' => 777,
+                  'message' => $sErrorMsg
+                 );
+// } else {
 }
 
-$iWordID = $oDB->getOne("select word_id,word_token, word, class, type, country_code, operator, search_name_count from word where word_token in (' a')");
-if (PEAR::isError($iWordID)) {
-    statusError('Query failed');
-}
-if (!$iWordID) {
-    statusError('No value');
-}
+header('content-type: application/json; charset=UTF-8');
+javascript_renderData($aResponse);
 
-echo 'OK';
 exit;


### PR DESCRIPTION
Replaces https://github.com/openstreetmap/Nominatim/pull/949

* The 2 minute hack is also gone, just like in master
* The date gets returned in ISO format instead of epoch timestamp (matches /details)
* json format will always return HTTP 200. Any errors will be in a status!=0 with a message string

Feel free to suggest another name for the `status` field or different status codes.