### PR TITLE
travis-ci: get rid of Python psycopg2 install warning

### DIFF
--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -20,7 +20,7 @@ sudo apt-get install -y -qq libboost-dev libboost-system-dev \
 
 sudo apt-get install -y -qq python3-dev python3-pip python3-psycopg2 php5-cgi
 
-pip3 install --quiet behave nose pytidylib psycopg2
+pip3 install --quiet behave nose pytidylib psycopg2-binary
 
 # Travis uses phpenv to support multiple PHP versions. We need to make sure
 # these packages get installed to the phpenv-set PHP (below /home/travis/.phpenv/),


### PR DESCRIPTION
fixes https://github.com/openstreetmap/Nominatim/issues/1004