### PR TITLE
add PHPCS Squiz.Arrays.ArrayDeclaration.KeyNotAligned rule

### DIFF
--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -33,33 +33,33 @@ $aPlaceDetails['rank_search'] = (int) $aPointDetails['rank_search'];
 
 $aPlaceDetails['isarea'] = ($aPointDetails['isarea'] == 't');
 $aPlaceDetails['centroid'] = array(
-    'type' => 'Point',
-    'coordinates' => array( (float) $aPointDetails['lon'], (float) $aPointDetails['lat'] )
-);
+                              'type' => 'Point',
+                              'coordinates' => array( (float) $aPointDetails['lon'], (float) $aPointDetails['lat'] )
+                             );
 
 $aPlaceDetails['geometry'] = json_decode($aPointDetails['asgeojson']);
 
 $funcMapAddressLine = function ($aFull) {
     $aMapped = array(
-        'localname' => $aFull['localname'],
-        'place_id' => isset($aFull['place_id']) ? (int) $aFull['place_id'] : null,
-        'osm_id' => isset($aFull['osm_id']) ? (int) $aFull['osm_id'] : null,
-        'osm_type' => isset($aFull['osm_type']) ? $aFull['osm_type'] : null,
-        'class' => $aFull['class'],
-        'type' => $aFull['type'],
-        'admin_level' => isset($aFull['admin_level']) ? (int) $aFull['admin_level'] : null,
-        'rank_address' => $aFull['rank_address'] ? (int) $aFull['rank_address'] : null,
-        'distance' => (float) $aFull['distance']
-    );
+                'localname' => $aFull['localname'],
+                'place_id' => isset($aFull['place_id']) ? (int) $aFull['place_id'] : null,
+                'osm_id' => isset($aFull['osm_id']) ? (int) $aFull['osm_id'] : null,
+                'osm_type' => isset($aFull['osm_type']) ? $aFull['osm_type'] : null,
+                'class' => $aFull['class'],
+                'type' => $aFull['type'],
+                'admin_level' => isset($aFull['admin_level']) ? (int) $aFull['admin_level'] : null,
+                'rank_address' => $aFull['rank_address'] ? (int) $aFull['rank_address'] : null,
+                'distance' => (float) $aFull['distance']
+               );
 
     return $aMapped;
 };
 
 $funcMapKeyword = function ($aFull) {
     $aMapped = array(
-        'id' => (int) $aFull['word_id'],
-        'token' => $aFull['word_token']
-    );
+                'id' => (int) $aFull['word_id'],
+                'token' => $aFull['word_token']
+               );
     return $aMapped;
 };
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -93,11 +93,12 @@
        INDENTATION, SPACING
        ************************************************************** -->
 
+  <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned" />
+
   <!-- Aligned looks nicer, but causes too many warnings currently -->
   <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
     <severity>0</severity>
   </rule>
-
 
 
 

--- a/test/php/Nominatim/DebugTest.php
+++ b/test/php/Nominatim/DebugTest.php
@@ -179,19 +179,19 @@ EOT
 
         // header are taken from first group item, thus no key3 gets printed
         $aGroups = array(
-            'group1' => array(
-                array('key1' => 'val1', 'key2' => 'val2'),
-                array('key1' => 'one', 'key2' => 'two', 'unknown' => 1),
-            ),
-            'group2' => array(
-                array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3'),
-            )
-        );
+                    'group1' => array(
+                                 array('key1' => 'val1', 'key2' => 'val2'),
+                                 array('key1' => 'one', 'key2' => 'two', 'unknown' => 1),
+                                ),
+                    'group2' => array(
+                                 array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3'),
+                                )
+                   );
         Debug::printGroupTable('Table3', $aGroups);
 
         $aGroups = array(
-            'group1' => array($this->oWithDebuginfo, $this->oWithDebuginfo),
-        );
+                    'group1' => array($this->oWithDebuginfo, $this->oWithDebuginfo),
+                   );
         Debug::printGroupTable('Table4', $aGroups);
     }
 }

--- a/website/status.php
+++ b/website/status.php
@@ -24,9 +24,9 @@ try {
 } catch (Exception $oErr) {
     if ($sOutputFormat == 'json') {
         $aResponse = array(
-                  'status' => $oErr->getCode(),
-                  'message' => $oErr->getMessage()
-                 );
+                      'status' => $oErr->getCode(),
+                      'message' => $oErr->getMessage()
+                     );
         javascript_renderData($aResponse);
     } else {
         header('HTTP/1.0 500 Internal Server Error');
@@ -39,10 +39,10 @@ try {
 if ($sOutputFormat == 'json') {
     $epoch = $oStatus->dataDate();
     $aResponse = array(
-              'status' => 0,
-              'message' => 'OK',
-              'data_updated' => (new DateTime('@'.$epoch))->format(DateTime::RFC3339)
-             );
+                  'status' => 0,
+                  'message' => 'OK',
+                  'data_updated' => (new DateTime('@'.$epoch))->format(DateTime::RFC3339)
+                 );
     javascript_renderData($aResponse);
 } else {
     echo 'OK';


### PR DESCRIPTION
PHPCS version 3 defaults seem to have removed this rule (can't find a hint in the changelog). Adding it makes sure PHPCS version 2.7 and 3 report the same errors on array key alignment. Also fixed those errors.