### PR TITLE
Better reverse geocoding

### DIFF
--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -557,10 +557,10 @@ class PlaceLookup
             if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ',ST_AsText(geometry) as astext';
             if ($fLonReverse != null && $fLatReverse != null) {
                 $sFrom = ' from (SELECT * , ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) AS closest_point';
+                $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             } else {
                 $sFrom = ' from placex where place_id = '.$iPlaceID;
             }
-            $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             if ($this->fPolygonSimplificationThreshold > 0) {
                 $sSQL .= ' from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,'.$this->fPolygonSimplificationThreshold.') as geometry'.$sFrom.') as plx';
             } else {

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -555,7 +555,11 @@ class PlaceLookup
             if ($this->bIncludePolygonAsKML) $sSQL .= ',ST_AsKML(geometry) as askml';
             if ($this->bIncludePolygonAsSVG) $sSQL .= ',ST_AsSVG(geometry) as assvg';
             if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ',ST_AsText(geometry) as astext';
-            $sFrom = ' from (SELECT * , ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) AS closest_point';
+            if ($fLonReverse != null && $fLatReverse != null) {
+                $sFrom = ' from (SELECT * , ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) AS closest_point';
+            } else {
+                $sFrom = $sFrom = ' from placex where place_id = '.$iPlaceID;
+            }
             $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             if ($this->fPolygonSimplificationThreshold > 0) {
                 $sSQL .= ' from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,'.$this->fPolygonSimplificationThreshold.') as geometry'.$sFrom.') as plx';

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -538,14 +538,8 @@ class PlaceLookup
             // Get the bounding box and outline polygon
             $sSQL = 'select place_id,0 as numfeatures,st_area(geometry) as area,';
             if ($fLonReverse != null && $fLatReverse != null) {
-                $sSQL .= ' CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN';
-                $sSQL .= ' ST_Y(closest_point)';
-                $sSQL .= ' ELSE ST_Y(centroid) ';
-                $sSQL .= ' END as centrelat, ';
-                $sSQL .= ' CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN';
-                $sSQL .= ' ST_X(closest_point)';
-                $sSQL .= ' ELSE ST_X(centroid) ';
-                $sSQL .= ' END as centrelon, ';
+                $sSQL .= ' ST_Y(closest_point) as centrelat,';
+                $sSQL .= ' ST_X(closest_point) as centrelon,';
             } else {
                 $sSQL .= ' ST_Y(centroid) as centrelat, ST_X(centroid) as centrelon,';
             }
@@ -557,7 +551,8 @@ class PlaceLookup
             if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ',ST_AsText(geometry) as astext';
             if ($fLonReverse != null && $fLatReverse != null) {
                 $sFrom = ' from (SELECT * , CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN ';
-                $sFrom .=' ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) END AS closest_point';
+                $sFrom .=' ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326))';
+                $sFrom .=' ELSE centroid END AS closest_point';
                 $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             } else {
                 $sFrom = ' from placex where place_id = '.$iPlaceID;

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -164,21 +164,19 @@ class PlaceLookup
 
         $aResults = $this->lookup(array($iPlaceID => new Result($iPlaceID)));
 
-        return empty($aResults) ? null : reset($aResults);
+        return sizeof($aResults) ? reset($aResults) : null;
     }
 
     public function lookup($aResults, $iMinRank = 0, $iMaxRank = 30)
     {
-        Debug::newFunction('Place lookup');
-
-        if (empty($aResults)) {
+        if (!sizeof($aResults)) {
             return array();
         }
         $aSubSelects = array();
 
         $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_PLACEX);
+        if (CONST_Debug) var_dump('PLACEX', $sPlaceIDs);
         if ($sPlaceIDs) {
-            Debug::printVar('Ids from placex', $sPlaceIDs);
             $sSQL  = 'SELECT ';
             $sSQL .= '    osm_type,';
             $sSQL .= '    osm_id,';
@@ -248,7 +246,6 @@ class PlaceLookup
         // postcode table
         $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_POSTCODE);
         if ($sPlaceIDs) {
-            Debug::printVar('Ids from location_postcode', $sPlaceIDs);
             $sSQL = 'SELECT';
             $sSQL .= "  'P' as osm_type,";
             $sSQL .= '  (SELECT osm_id from placex p WHERE p.place_id = lp.parent_place_id) as osm_id,';
@@ -279,7 +276,6 @@ class PlaceLookup
             if (CONST_Use_US_Tiger_Data) {
                 $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_TIGER);
                 if ($sPlaceIDs) {
-                    Debug::printVar('Ids from Tiger table', $sPlaceIDs);
                     $sHousenumbers = Result::sqlHouseNumberTable($aResults, Result::TABLE_TIGER);
                     // Tiger search only if a housenumber was searched and if it was found
                     // (realized through a join)
@@ -325,7 +321,6 @@ class PlaceLookup
             // osmline - interpolated housenumbers
             $sPlaceIDs = Result::joinIdsByTable($aResults, Result::TABLE_OSMLINE);
             if ($sPlaceIDs) {
-                Debug::printVar('Ids from interpolation', $sPlaceIDs);
                 $sHousenumbers = Result::sqlHouseNumberTable($aResults, Result::TABLE_OSMLINE);
                 // interpolation line search only if a housenumber was searched
                 // (realized through a join)
@@ -411,13 +406,16 @@ class PlaceLookup
             }
         }
 
-        if (empty($aSubSelects)) {
+        if (CONST_Debug) var_dump($aSubSelects);
+
+        if (!sizeof($aSubSelects)) {
             return array();
         }
 
-        $sSQL = join(' UNION ', $aSubSelects);
-        Debug::printSQL($sSQL);
-        $aPlaces = chksql($this->oDB->getAll($sSQL), 'Could not lookup place');
+        $aPlaces = chksql(
+            $this->oDB->getAll(join(' UNION ', $aSubSelects)),
+            'Could not lookup place'
+        );
 
         $aClassType = getClassTypes();
         foreach ($aPlaces as &$aPlace) {
@@ -459,12 +457,12 @@ class PlaceLookup
             $aPlace['addresstype'] = $sAddressType;
         }
 
-        Debug::printVar('Places', $aPlaces);
+        if (CONST_Debug) var_dump($aPlaces);
 
         return $aPlaces;
     }
 
-    public function getAddressDetails($iPlaceID, $bAll = false, $sHousenumber = -1)
+    private function getAddressDetails($iPlaceID, $bAll, $sHousenumber)
     {
         $sSQL = 'SELECT *,';
         $sSQL .= '  get_name_by_language(name,'.$this->aLangPrefOrderSql.') as localname';
@@ -528,7 +526,7 @@ class PlaceLookup
      */
 
 
-    public function getOutlines($iPlaceID, $fLon = null, $fLat = null, $fRadius = null)
+    public function getOutlines($iPlaceID, $fLon = null, $fLat = null, $fRadius = null, $fLonReverse = null, $fLatReverse = null)
     {
 
         $aOutlineResult = array();
@@ -536,10 +534,23 @@ class PlaceLookup
 
         if (CONST_Search_AreaPolygons) {
             // Get the bounding box and outline polygon
-            $sSQL  = 'select place_id,0 as numfeatures,st_area(geometry) as area,';
-            $sSQL .= 'ST_Y(centroid) as centrelat,ST_X(centroid) as centrelon,';
-            $sSQL .= 'ST_YMin(geometry) as minlat,ST_YMax(geometry) as maxlat,';
-            $sSQL .= 'ST_XMin(geometry) as minlon,ST_XMax(geometry) as maxlon';
+            $sSQL = 'select place_id,0 as numfeatures,st_area(geometry) as area,';
+            if ($fLonReverse != null && $fLatReverse != null) {
+                $sSQL .= ' CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN';
+                $sSQL .= ' ST_Y(ST_LineInterpolatePoint(geometry,';
+                $sSQL .= ' ST_LineLocatePoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326))))';
+                $sSQL .= ' ELSE ST_Y(centroid) ';
+                $sSQL .= ' END as centrelat, ';
+                $sSQL .= ' CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN';
+                $sSQL .= ' ST_X(ST_LineInterpolatePoint(geometry,';
+                $sSQL .= ' ST_LineLocatePoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326))))';
+                $sSQL .= ' ELSE ST_X(centroid) ';
+                $sSQL .= ' END as centrelon, ';
+            } else {
+                $sSQL .= ' ST_Y(centroid) as centrelat, ST_X(centroid) as centrelon,';
+            }
+            $sSQL .= ' ST_YMin(geometry) as minlat,ST_YMax(geometry) as maxlat,';
+            $sSQL .= ' ST_XMin(geometry) as minlon,ST_XMax(geometry) as maxlon';
             if ($this->bIncludePolygonAsGeoJSON) $sSQL .= ',ST_AsGeoJSON(geometry) as asgeojson';
             if ($this->bIncludePolygonAsKML) $sSQL .= ',ST_AsKML(geometry) as askml';
             if ($this->bIncludePolygonAsSVG) $sSQL .= ',ST_AsSVG(geometry) as assvg';

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -556,7 +556,8 @@ class PlaceLookup
             if ($this->bIncludePolygonAsSVG) $sSQL .= ',ST_AsSVG(geometry) as assvg';
             if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ',ST_AsText(geometry) as astext';
             if ($fLonReverse != null && $fLatReverse != null) {
-                $sFrom = ' from (SELECT * , ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) AS closest_point';
+                $sFrom = ' from (SELECT * , CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN ';
+                $sFrom .=' ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) END AS closest_point';
                 $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             } else {
                 $sFrom = ' from placex where place_id = '.$iPlaceID;

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -558,7 +558,7 @@ class PlaceLookup
             if ($fLonReverse != null && $fLatReverse != null) {
                 $sFrom = ' from (SELECT * , ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326)) AS closest_point';
             } else {
-                $sFrom = $sFrom = ' from placex where place_id = '.$iPlaceID;
+                $sFrom = ' from placex where place_id = '.$iPlaceID;
             }
             $sFrom .= ' from placex where place_id = '.$iPlaceID.') as plx';
             if ($this->fPolygonSimplificationThreshold > 0) {

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -89,7 +89,7 @@ class ReverseGeocode
             $iRankSearch = $aPoly['rank_search'];
             $iGeometry = $aPoly['geometry'];
             
-            $sSQL = 'select place_id,parent_place_id,rank_search,country_code,';
+            $sSQL = 'select place_id,parent_place_id,rank_search,country_code, linked_place_id,';
             $sSQL .='  ST_distance('.$sPointSQL.', geometry) as distance';
             $sSQL .= ' FROM placex';
             $sSQL .= ' WHERE osm_type = \'N\'';
@@ -194,17 +194,26 @@ class ReverseGeocode
                 }else{
                     $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
                     if ($aPlace) {
-                        $oResult = new Result($aPlace['place_id']);
+                        // if place node is found adress goes over linked_place_id
+                        if (!empty($aPlace['linked_place_id'])) {
+                            $oResult = new Result($aPlace['linked_place_id']);
+                        }else{
+                            $oResult = new Result($aPlace['place_id']);
+                        }
                     }
                 }
             // lower than street level ($iMaxRank < 26 )
             }else{
                 $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
                 if ($aPlace) {
-                    $oResult = new Result($aPlace['place_id']);
+                // if place node is found adress goes over linked_place_id
+                    if (!empty($aPlace['linked_place_id'])) {
+                        $oResult = new Result($aPlace['linked_place_id']);
+                    }else{
+                        $oResult = new Result($aPlace['place_id']);
+                    }
+                }
             }
-            
-        }  
         return $oResult;
     }
 

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -127,10 +127,6 @@ class ReverseGeocode
     
     protected function lookupPolygon($sPointSQL, $iMaxRank)
     {
-    
-        $oResult = null;
-        $aPlace = null;
-        
         $sSQL = 'SELECT * FROM';
         $sSQL .= '(select place_id,parent_place_id,rank_address, rank_search, country_code, geometry';
         $sSQL .= ' FROM placex';
@@ -253,6 +249,9 @@ class ReverseGeocode
                 $iParentPlaceID = $aPlace['parent_place_id'];
                 
                 if ($bDoInterpolation && $iMaxRank >= 30) {
+                    if ($aPlace['rank_address'] <=27) {
+                        $iDistance = 0.001;
+                    }
                     $aHouse = $this->lookupInterpolation($sPointSQL, $iDistance);
 
                     if ($aHouse) {
@@ -282,7 +281,7 @@ class ReverseGeocode
                         'Could not determine closest place.'
                     );
                     if ($aStreet) {
-                        $iDistance = $aPlace['distance'];
+                        $iDistance = $aStreet['distance'];
                         $iPlaceID = $aStreet['place_id'];
                         $oResult = new Result($iPlaceID);
                         $iParentPlaceID = $aStreet['parent_place_id'];

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -87,7 +87,7 @@ class ReverseGeocode
         if ($aPoly) {
             $iParentPlaceID = $aPoly['parent_place_id'];
             $iRankSearch = $aPoly['rank_search'];
-            $iGeometry = $aPoly['geometry'];
+            $iPlaceID = $aPoly['place_id'];
             
             $sSQL = 'select place_id,parent_place_id,rank_search,country_code, linked_place_id,';
             $sSQL .='  ST_distance('.$sPointSQL.', geometry) as distance';
@@ -95,9 +95,10 @@ class ReverseGeocode
             $sSQL .= ' WHERE osm_type = \'N\'';
             $sSQL .= ' AND rank_search >= '.$iRankSearch;
             $sSQL .= ' AND rank_search <= LEAST(25, '.$iMaxRank.')';
-            $sSQL .= ' AND ST_CONTAINS(\''.$iGeometry.'\'::geometry, geometry )';
+            $sSQL .= ' AND ST_CONTAINS((SELECT geometry FROM placex WHERE place_id = '.$iPlaceID.'), geometry )';
             $sSQL .= ' AND type != \'postcode\'';
             $sSQL .= ' AND name IS NOT NULL ';
+            $sSQL .= ' AND class not in ( \'waterway\')';
             $sSQL .= ' ORDER BY distance ASC,';
             $sSQL .= ' rank_search DESC';
             $sSQL .= ' limit 1';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -266,7 +266,7 @@ class ReverseGeocode
                 $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
                 if ($aPlace) {
                     $oResult = new Result($aPlace['place_id']);
-                } else {
+                } elseif(!$aPlace && $iMaxRank > 4)  {
                     $aPlace = $this->noPolygonFound($sPointSQL, $iMaxRank);
                     if ($aPlace) {
                         $oResult = new Result($aPlace['place_id']);
@@ -278,7 +278,7 @@ class ReverseGeocode
             $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
             if ($aPlace) {
                 $oResult = new Result($aPlace['place_id']);
-            } else {
+            } elseif(!$aPlace && $iMaxRank > 4) {
                 $aPlace = $this->noPolygonFound($sPointSQL, $iMaxRank);
                 if ($aPlace) {
                     $oResult = new Result($aPlace['place_id']);

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -150,6 +150,15 @@ class ReverseGeocode
             $iRankSearch = $aPoly['rank_search'];
             $iPlaceID = $aPoly['place_id'];
             
+            //search diameter for the place node search
+            if ($iMaxRank <= 30) $fSearchDiam = 0.1;
+            if ($iMaxRank <= 18) $fSearchDiam = 0.2;
+            if ($iMaxRank <= 17) $fSearchDiam = 0.6;
+            if ($iMaxRank <= 12) $fSearchDiam = 0.8;
+            if ($iMaxRank <= 10) $fSearchDiam = 1;
+            if ($iMaxRank <= 8) $fSearchDiam = 2;
+            if ($iMaxRank <= 4) $fSearchDiam = 4;
+            
             if ($iRankAddress != $iMaxRank) {
                 $sSQL = 'SELECT *';
                 $sSQL .= ' FROM (';
@@ -166,6 +175,7 @@ class ReverseGeocode
                     $sSQL .= ' AND rank_address > '.$iRankAddress;
                     $sSQL .= ' AND rank_address <= ' .Min(25, $iMaxRank);
                 }
+                $sSQL .= ' AND ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
                 $sSQL .= ' AND type != \'postcode\'';
                 $sSQL .= ' AND name IS NOT NULL ';
                 $sSQL .= ' and indexed_status = 0 and linked_place_id is null';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -103,6 +103,8 @@ class ReverseGeocode
             $sSQL .= ' AND type != \'postcode\'';
             $sSQL .= ' AND name IS NOT NULL ';
             $sSQL .= ' and class not in (\'waterway\',\'railway\',\'tunnel\',\'bridge\',\'man_made\')';
+            // preselection through bbox
+            $sSQL .= ' AND (SELECT geometry FROM placex WHERE place_id = '.$iPlaceID.') && geometry';
             $sSQL .= ' ORDER BY distance ASC,';
             $sSQL .= ' rank_address DESC';
             $sSQL .= ' limit 500) as a';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -68,6 +68,50 @@ class ReverseGeocode
             'Could not determine closest housenumber on an osm interpolation line.'
         );
     }
+    
+    protected function lookupPolygon($sPointSQL, $iMaxRank)
+    {
+        $sSQL = 'select place_id,parent_place_id,rank_search,country_code, geometry';
+        $sSQL .= ' FROM placex';
+        $sSQL .= ' WHERE ST_GeometryType(geometry) in (\'ST_Polygon\',\'ST_MultiPolygon\')';
+        $sSQL .= ' AND rank_search <= LEAST(25, '.$iMaxRank.')';
+        $sSQL .= ' AND ST_CONTAINS(geometry, '.$sPointSQL.' )';
+        $sSQL .= ' AND type != \'postcode\' ';
+        $sSQL .= ' AND name IS NOT NULL ';
+        $sSQL .= ' ORDER BY rank_search DESC LIMIT 1';
+
+        $aPoly = chksql(
+            $this->oDB->getRow($sSQL),
+            'Could not determine polygon containing the point.'
+        );
+        if ($aPoly) {
+            $iParentPlaceID = $aPoly['parent_place_id'];
+            $iRankSearch = $aPoly['rank_search'];
+            $iGeometry = $aPoly['geometry'];
+            
+            $sSQL = 'select place_id,parent_place_id,rank_search,country_code,';
+            $sSQL .='  ST_distance('.$sPointSQL.', geometry) as distance';
+            $sSQL .= ' FROM placex';
+            $sSQL .= ' WHERE osm_type = \'N\'';
+            $sSQL .= ' AND rank_search >= '.$iRankSearch;
+            $sSQL .= ' AND rank_search <= LEAST(25, '.$iMaxRank.')';
+            $sSQL .= ' AND ST_CONTAINS(\''.$iGeometry.'\'::geometry, geometry )';
+            $sSQL .= ' AND type != \'postcode\'';
+            $sSQL .= ' AND name IS NOT NULL ';
+            $sSQL .= ' ORDER BY distance ASC,';
+            $sSQL .= ' rank_search DESC';
+            $sSQL .= ' limit 1';
+            if (CONST_Debug) var_dump($sSQL);
+            $aPlacNode = chksql(
+                $this->oDB->getRow($sSQL),
+                'Could not determine place node.'
+            );
+            if ($aPlacNode) {
+                return $aPlacNode;
+            }
+        }
+        return $aPoly;
+    }
 
     public function lookup($fLat, $fLon, $bDoInterpolation = true)
     {
@@ -79,61 +123,36 @@ class ReverseGeocode
 
     public function lookupPoint($sPointSQL, $bDoInterpolation = true)
     {
+        
         $iMaxRank = $this->iMaxRank;
 
         // Find the nearest point
-        $fSearchDiam = 0.0004;
+        $fSearchDiam = 0.006;
         $oResult = null;
         $aPlace = null;
         $fMaxAreaDistance = 1;
         $bIsTigerStreet = false;
-        while ($oResult === null && $fSearchDiam < $fMaxAreaDistance) {
-            $fSearchDiam = $fSearchDiam * 2;
-
-            // If we have to expand the search area by a large amount then we need a larger feature
-            // then there is a limit to how small the feature should be
-            if ($fSearchDiam > 2 && $iMaxRank > 4) $iMaxRank = 4;
-            if ($fSearchDiam > 1 && $iMaxRank > 9) $iMaxRank = 8;
-            if ($fSearchDiam > 0.8 && $iMaxRank > 10) $iMaxRank = 10;
-            if ($fSearchDiam > 0.6 && $iMaxRank > 12) $iMaxRank = 12;
-            if ($fSearchDiam > 0.2 && $iMaxRank > 17) $iMaxRank = 17;
-            if ($fSearchDiam > 0.1 && $iMaxRank > 18) $iMaxRank = 18;
-            if ($fSearchDiam > 0.008 && $iMaxRank > 22) $iMaxRank = 22;
-            if ($fSearchDiam > 0.001 && $iMaxRank > 26) {
-                // try with interpolations before continuing
-                if ($bDoInterpolation) {
-                    $aHouse = $this->lookupInterpolation($sPointSQL, $fSearchDiam/2);
-
-                    if ($aHouse) {
-                        $oResult = new Result($aHouse['place_id'], Result::TABLE_OSMLINE);
-                        $oResult->iHouseNumber = closestHouseNumber($aHouse);
-
-                        $aPlace = $aHouse;
-                        $iParentPlaceID = $aHouse['parent_place_id']; // the street
-                        $iMaxRank = 30;
-
-                        break;
-                    }
-                }
-                // no interpolation found, continue search
-                $iMaxRank = 26;
-            }
-
+        
+        // for POI or street level
+        if ( $iMaxRank >= 26 ) {
+            
             $sSQL = 'select place_id,parent_place_id,rank_search,country_code,';
-            $sSQL .= '  ST_distance('.$sPointSQL.', geometry) as distance';
+            $sSQL .= 'CASE WHEN ST_GeometryType(geometry) in (\'ST_Polygon\',\'ST_MultiPolygon\') THEN ST_distance('.$sPointSQL.', centroid)';
+            $sSQL .= ' ELSE ST_distance('.$sPointSQL.', geometry) ';
+            $sSQL .= ' END as distance';
             $sSQL .= ' FROM ';
-            if ($fSearchDiam < 0.01) {
-                $sSQL .= ' placex';
-                $sSQL .= '   WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
-                $sSQL .= '   AND';
+            $sSQL .= ' placex';
+            $sSQL .= '   WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
+            $sSQL .= '   AND';
+            // only streets
+            if ($iMaxRank == 26) {
+                $sSQL .= ' rank_search != 28 and rank_search = 26';
             } else {
-                $sSQL .= ' (SELECT * FROM placex ';
-                $sSQL .= '   WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
-                $sSQL .= '   LIMIT 1000) as p WHERE';
+                $sSQL .= ' rank_search != 28 and rank_search >= 26';
             }
-            $sSQL .= ' rank_search != 28 and rank_search >= '.$iMaxRank;
             $sSQL .= ' and (name is not null or housenumber is not null';
             $sSQL .= '      or rank_search between 26 and 27)';
+            $sSQL .= ' and type not in (\'proposed\')';
             $sSQL .= ' and class not in (\'waterway\',\'railway\',\'tunnel\',\'bridge\',\'man_made\')';
             $sSQL .= ' and indexed_status = 0 and linked_place_id is null';
             $sSQL .= ' and (ST_GeometryType(geometry) not in (\'ST_Polygon\',\'ST_MultiPolygon\') ';
@@ -144,80 +163,49 @@ class ReverseGeocode
                 $this->oDB->getRow($sSQL),
                 'Could not determine closest place.'
             );
+            
             if ($aPlace) {
-                $oResult = new Result($aPlace['place_id']);
-                $iParentPlaceID = $aPlace['parent_place_id'];
-                if ($bDoInterpolation) {
-                    if ($aPlace['rank_search'] == 26 || $aPlace['rank_search'] == 27) {
-                        $bIsTigerStreet = ($aPlace['country_code'] == 'us');
-                    } elseif ($aPlace['rank_search'] == 30) {
-                        // If a house was found, make sure there isn't an
-                        // interpolation line that is closer.
-                        $aHouse = $this->lookupInterpolation(
-                            $sPointSQL,
-                            $aPlace['distance']
+                    $iPlaceID = $aPlace['place_id'];
+                    $oResult = new Result($iPlaceID);
+                    $iParentPlaceID = $aPlace['parent_place_id'];
+                    // if street and maxrank > streetlevel
+                    if (($aPlace['rank_search'] == 26 || $aPlace['rank_search'] == 27)&& $iMaxRank > 27 ) {
+                        // find the closest object (up to a certain radius) of which the street is a parent of
+                        $sSQL = ' select place_id,parent_place_id,rank_search,country_code,';
+                        $sSQL .= ' ST_distance('.$sPointSQL.', geometry) as distance';
+                        $sSQL .= ' FROM ';
+                        $sSQL .= ' placex';
+                        // radius ?
+                        $sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', geometry, 0.003)';
+                        $sSQL .= ' AND parent_place_id = '.$iPlaceID;
+                        $sSQL .= ' and (name is not null or housenumber is not null)';
+                        $sSQL .= ' ORDER BY distance ASC limit 1';
+                        if (CONST_Debug) var_dump($sSQL);
+                        $aStreet = chksql(
+                            $this->oDB->getRow($sSQL),
+                            'Could not determine closest place.'
                         );
-                        if ($aHouse && $aPlace['distance'] < $aHouse['distance']) {
-                            $oResult = new Result(
-                                $aHouse['place_id'],
-                                Result::TABLE_OSMLINE
-                            );
-                            $oResult->iHouseNumber = closestHouseNumber($aHouse);
-
-                            $aPlace = $aHouse;
-                            $iParentPlaceID = $aHouse['parent_place_id'];
+                        if ($aStreet) {
+                            $iPlaceID = $aStreet['place_id'];
+                            $oResult = new Result($iPlaceID);
+                            $iParentPlaceID = $aStreet['parent_place_id'];
                         }
+                    } 
+                }else{
+                    $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
+                    if ($aPlace) {
+                        $oResult = new Result($aPlace['place_id']);
                     }
                 }
+            // lower than street level ($iMaxRank < 26 )
+            }else{
+                $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
+                if ($aPlace) {
+                    $oResult = new Result($aPlace['place_id']);
             }
-        }
-
-        // Only street found? In the US we can check TIGER data for nearest housenumber
-        if (CONST_Use_US_Tiger_Data && $bIsTigerStreet && $this->iMaxRank >= 28) {
-            $fSearchDiam = $aPlace['rank_search'] > 28 ? $aPlace['distance'] : 0.001;
-            $sSQL = 'SELECT place_id,parent_place_id,30 as rank_search,';
-            $sSQL .= 'ST_LineLocatePoint(linegeo,'.$sPointSQL.') as fraction,';
-            $sSQL .= 'ST_distance('.$sPointSQL.', linegeo) as distance,';
-            $sSQL .= 'startnumber,endnumber,interpolationtype';
-            $sSQL .= ' FROM location_property_tiger WHERE parent_place_id = '.$oResult->iId;
-            $sSQL .= ' AND ST_DWithin('.$sPointSQL.', linegeo, '.$fSearchDiam.')';
-            $sSQL .= ' ORDER BY distance ASC limit 1';
-
-            if (CONST_Debug) var_dump($sSQL);
-
-            $aPlaceTiger = chksql(
-                $this->oDB->getRow($sSQL),
-                'Could not determine closest Tiger place.'
-            );
-            if ($aPlaceTiger) {
-                if (CONST_Debug) var_dump('found Tiger housenumber', $aPlaceTiger);
-                $aPlace = $aPlaceTiger;
-                $oResult = new Result($aPlace['place_id'], Result::TABLE_TIGER);
-                $oResult->iHouseNumber = closestHouseNumber($aPlaceTiger);
-                $iParentPlaceID = $aPlace['parent_place_id'];
-                $iMaxRank = 30;
-            }
-        }
-
-        // The point we found might be too small - use the address to find what it is a child of
-        if ($oResult !== null && $iMaxRank < 28) {
-            if ($aPlace['rank_search'] > 28 && $iParentPlaceID) {
-                $iPlaceID = $iParentPlaceID;
-            } else {
-                $iPlaceID = $oResult->iId;
-            }
-            $sSQL  = 'select a.address_place_id';
-            $sSQL .= ' FROM place_addressline a, placex p';
-            $sSQL .= " WHERE a.place_id = $iPlaceID and a.address_place_id = p.place_id";
-            $sSQL .= '   AND p.linked_place_id is null';
-            $sSQL .= " ORDER BY abs(cached_rank_address - $iMaxRank) asc,cached_rank_address desc,isaddress desc,distance desc";
-            $sSQL .= ' LIMIT 1';
-            $iPlaceID = chksql($this->oDB->getOne($sSQL), 'Could not get parent for place.');
-            if ($iPlaceID) {
-                $oResult = new Result($iPlaceID);
-            }
-        }
-
+            
+        }  
         return $oResult;
     }
+
 }

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -127,8 +127,10 @@ class ReverseGeocode
     
     protected function lookupPolygon($sPointSQL, $iMaxRank)
     {
-        
+        // polygon search begins at suburb-level
         if ($iMaxRank > 25) $iMaxRank = 25;
+        // no polygon search over country-level
+        if ($iMaxRank < 4) $iMaxRank = 4;
         
         $sSQL = 'SELECT * FROM';
         $sSQL .= '(select place_id,parent_place_id,rank_address, rank_search, country_code, geometry';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -142,7 +142,7 @@ class ReverseGeocode
                 $sSQL .= ' FROM placex';
                 $sSQL .= ' WHERE osm_type = \'N\'';
                 if ($iRankAddress = 16){
-                //  using rank_search beacause of a better differentiation for place nodes at rank_address 16
+                //  using rank_search because of a better differentiation for place nodes at rank_address 16
                     $sSQL .= ' AND rank_search > '.$iRankSearch;
                     $sSQL .= ' AND rank_search <= ' .Min(25, $iMaxRank);
                     $sSQL .= ' AND class = \'place\'';

--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -15,7 +15,7 @@ CREATE INDEX idx_placex_rank_address ON placex USING BTREE (rank_address) {ts:se
 CREATE INDEX idx_placex_pendingsector ON placex USING BTREE (rank_search,geometry_sector) {ts:address-index} where indexed_status > 0;
 CREATE INDEX idx_placex_parent_place_id ON placex USING BTREE (parent_place_id) {ts:search-index} where parent_place_id IS NOT NULL;
 CREATE INDEX idx_placex_geometry_reverse_lookupPoint ON placex USING gist (geometry) {ts:search-index}
-where (name is not null or housenumber is not null or) and class not in ('waterway','railway','tunnel','bridge','man_made') and rank_address >= 26 and indexed_status = 0 and linked_place_id is null;
+where (name is not null or housenumber is not null) and class not in ('waterway','railway','tunnel','bridge','man_made') and rank_address >= 26 and indexed_status = 0 and linked_place_id is null;
 CREATE INDEX idx_placex_geometry_reverse_lookupPolygon ON placex USING gist (geometry) {ts:search-index} where St_GeometryType(geometry) in ('ST_Polygon', 'ST_MultiPolygon') and rank_address <= 25 and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
 CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_search ON placex USING gist (geometry) {ts:search-index} where
 osm_type = 'N' and rank_search > 0 and rank_search <= 25 and class = 'place' and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;

--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -14,7 +14,14 @@ CREATE INDEX idx_placex_rank_search ON placex USING BTREE (rank_search) {ts:sear
 CREATE INDEX idx_placex_rank_address ON placex USING BTREE (rank_address) {ts:search-index};
 CREATE INDEX idx_placex_pendingsector ON placex USING BTREE (rank_search,geometry_sector) {ts:address-index} where indexed_status > 0;
 CREATE INDEX idx_placex_parent_place_id ON placex USING BTREE (parent_place_id) {ts:search-index} where parent_place_id IS NOT NULL;
-CREATE INDEX idx_placex_reverse_geometry ON placex USING gist (geometry) {ts:search-index} where rank_search != 28 and (name is not null or housenumber is not null or rank_search between 26 and 27) and class not in ('waterway','railway','tunnel','bridge','man_made');
+CREATE INDEX idx_placex_geometry_reverse_lookupPoint ON placex USING gist (geometry) {ts:search-index}
+where (name is not null or housenumber is not null or) and class not in ('waterway','railway','tunnel','bridge','man_made') and rank_address >= 26 and indexed_status = 0 and linked_place_id is null;
+CREATE INDEX idx_placex_geometry_reverse_lookupPolygon ON placex USING gist (geometry) {ts:search-index} where St_GeometryType(geometry) in ('ST_Polygon', 'ST_MultiPolygon') and rank_address <= 25 and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
+CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_search ON placex USING gist (geometry) {ts:search-index} where
+osm_type = 'N' and rank_search > 0 and rank_search <= 25 and class = 'place' and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
+CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_address ON placex USING gist (geometry) {ts:search-index} where
+osm_type = 'N' and rank_address > 0 and rank_address <= 25 and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
+
 CREATE INDEX idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
 
 CREATE INDEX idx_osmline_parent_place_id ON location_property_osmline USING BTREE (parent_place_id) {ts:search-index};

--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -21,6 +21,7 @@ CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_search ON placex USING g
 osm_type = 'N' and rank_search > 0 and rank_search <= 25 and class = 'place' and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
 CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_address ON placex USING gist (geometry) {ts:search-index} where
 osm_type = 'N' and rank_address > 0 and rank_address <= 25 and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
+GRANT SELECT ON Table country_osm_grid to "www-data";
 
 CREATE INDEX idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
 

--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -21,7 +21,7 @@ CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_search ON placex USING g
 osm_type = 'N' and rank_search > 0 and rank_search <= 25 and class = 'place' and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
 CREATE INDEX idx_placex_geometry_reverse_placeNode_rank_address ON placex USING gist (geometry) {ts:search-index} where
 osm_type = 'N' and rank_address > 0 and rank_address <= 25 and type != 'postcode' and name is not null and indexed_status = 0 and linked_place_id is null;
-GRANT SELECT ON Table country_osm_grid to "www-data";
+GRANT SELECT ON Table country_osm_grid to "{www-user}";
 
 CREATE INDEX idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
 

--- a/test/bdd/api/reverse/queries.feature
+++ b/test/bdd/api/reverse/queries.feature
@@ -48,6 +48,8 @@ Feature: Reverse geocoding
 
     Scenario: Location off the coast
         When sending jsonv2 reverse coordinates 54.046489113,8.5546870529
+	 | zoom |
+         | 5 |
         Then results contain
          | display_name |
          | ^.*Hamburg, Deutschland |

--- a/test/bdd/api/reverse/simple.feature
+++ b/test/bdd/api/reverse/simple.feature
@@ -70,7 +70,7 @@ Feature: Simple Reverse Tests
     Scenario Outline: Boundingbox is returned
         When sending <format> reverse coordinates 14.62,108.1
           | zoom |
-          | 4 |
+          | 8 |
         Then result has bounding box in 9,20,102,113
 
     Examples:

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -596,6 +596,7 @@ if ($aCMDResult['create-search-indices'] || $aCMDResult['all']) {
     $bDidSomething = true;
 
     $sTemplate = file_get_contents(CONST_BasePath.'/sql/indices.src.sql');
+    $sTemplate = str_replace('{www-user}', CONST_Database_Web_User, $sTemplate);
     $sTemplate = replace_tablespace(
         '{ts:address-index}',
         CONST_Tablespace_Address_Index,

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -55,7 +55,9 @@ if (isset($aPlace)) {
         $aPlace['place_id'],
         $aPlace['lon'],
         $aPlace['lat'],
-        $fRadius
+        $fRadius, 
+        $fLat, 
+        $fLon 
     );
 
     if ($aOutlineResult) {

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -41,7 +41,7 @@ if ($sOsmType && $iOsmId > 0) {
 
     if ($oLookup) {
         $aPlaces = $oPlaceLookup->lookup(array($oLookup->iId => $oLookup));
-        if (!empty($aPlaces)) {
+        if (sizeof($aPlaces)) {
             $aPlace = reset($aPlaces);
         }
     }
@@ -55,14 +55,16 @@ if (isset($aPlace)) {
         $aPlace['place_id'],
         $aPlace['lon'],
         $aPlace['lat'],
-        $fRadius
+        $fRadius,
+        $fLat,
+        $fLon
     );
 
     if ($aOutlineResult) {
         $aPlace = array_merge($aPlace, $aOutlineResult);
     }
 } else {
-    $aPlace = array();
+    $aPlace = [];
 }
 
 
@@ -72,10 +74,8 @@ if (CONST_Debug) {
 }
 
 if ($sOutputFormat == 'html') {
-    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
     $sTileURL = CONST_Map_Tile_URL;
     $sTileAttribution = CONST_Map_Tile_Attribution;
 }
-
-$sOutputTemplate = ($sOutputFormat=='jsonv2' ? 'json' : $sOutputFormat);
-include(CONST_BasePath.'/lib/template/address-'.$sOutputTemplate.'.php');
+include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -41,7 +41,7 @@ if ($sOsmType && $iOsmId > 0) {
 
     if ($oLookup) {
         $aPlaces = $oPlaceLookup->lookup(array($oLookup->iId => $oLookup));
-        if (sizeof($aPlaces)) {
+        if (!empty($aPlaces)) {
             $aPlace = reset($aPlaces);
         }
     }
@@ -55,16 +55,14 @@ if (isset($aPlace)) {
         $aPlace['place_id'],
         $aPlace['lon'],
         $aPlace['lat'],
-        $fRadius,
-        $fLat,
-        $fLon
+        $fRadius
     );
 
     if ($aOutlineResult) {
         $aPlace = array_merge($aPlace, $aOutlineResult);
     }
 } else {
-    $aPlace = [];
+    $aPlace = array();
 }
 
 
@@ -74,8 +72,10 @@ if (CONST_Debug) {
 }
 
 if ($sOutputFormat == 'html') {
-    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+    $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
     $sTileURL = CONST_Map_Tile_URL;
     $sTileAttribution = CONST_Map_Tile_Attribution;
 }
-include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');
+
+$sOutputTemplate = ($sOutputFormat=='jsonv2' ? 'json' : $sOutputFormat);
+include(CONST_BasePath.'/lib/template/address-'.$sOutputTemplate.'.php');


### PR DESCRIPTION
I improved the reverese geocoding algorithm:
geocoding at zoom > 16 looks for streets and POIs. If a street is found, the algorithm looks for POIs that the street is a parent of. If no object is found or  zoom < 16, the algorithm searches for polygons which contain the searched point. Inside the polygon with highest rank, the algorithm searches for place nodes with a higher rank than the polygon. 

