### PR TITLE
limit default threads to 15

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -61,8 +61,8 @@ if ($aCMDResult['import-data'] || $aCMDResult['all']) {
 }
 
 
-// This is a pretty hard core default - the number of processors in the box - 1
-$iInstances = isset($aCMDResult['threads'])?$aCMDResult['threads']:(getProcessorCount()-1);
+// by default, use all but one processor, but never more than 15.
+$iInstances = isset($aCMDResult['threads'])?$aCMDResult['threads']:(min(16,getProcessorCount())-1);
 if ($iInstances < 1) {
     $iInstances = 1;
     warn("resetting threads to $iInstances");


### PR DESCRIPTION
When no explicit number of threads is given, don't simply use getProcessorCount()-1, but limit to max. 15