### PR TITLE
Enable Postgres to run on a different host than the web server

### DIFF
--- a/data/words.sql
+++ b/data/words.sql
@@ -18,12 +18,12 @@ SET default_with_oids = false;
 -- Name: word_frequencies; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
+DROP TABLE IF EXISTS word_frequencies;
+
 CREATE TABLE word_frequencies (
     word_token text,
     count bigint
 );
-
-TRUNCATE TABLE word_frequencies;
 
 --
 -- Data for Name: word_frequencies; Type: TABLE DATA; Schema: public; Owner: -

--- a/data/words.sql
+++ b/data/words.sql
@@ -23,6 +23,7 @@ CREATE TABLE word_frequencies (
     count bigint
 );
 
+TRUNCATE TABLE word_frequencies;
 
 --
 -- Data for Name: word_frequencies; Type: TABLE DATA; Schema: public; Owner: -

--- a/docs/admin/Faq.md
+++ b/docs/admin/Faq.md
@@ -112,7 +112,7 @@ to get the full error message.
 On CentOS v7 the PostgreSQL server is started with `systemd`.
 Check if `/usr/lib/systemd/system/httpd.service` contains a line `PrivateTmp=true`.
 If so then Apache cannot see the `/tmp/.s.PGSQL.5432` file. It's a good security feature,
-so use the [preferred solution](../appendix/Install-on-Centos-7/#adding-selinux-security-settings).
+so use the [[#PostgreSQL_UNIX_Socket_Location_on_CentOS|preferred solution]]
 
 However, you can solve this the quick and dirty way by commenting out that line and then run
 

--- a/docs/admin/Faq.md
+++ b/docs/admin/Faq.md
@@ -112,7 +112,7 @@ to get the full error message.
 On CentOS v7 the PostgreSQL server is started with `systemd`.
 Check if `/usr/lib/systemd/system/httpd.service` contains a line `PrivateTmp=true`.
 If so then Apache cannot see the `/tmp/.s.PGSQL.5432` file. It's a good security feature,
-so use the [[#PostgreSQL_UNIX_Socket_Location_on_CentOS|preferred solution]]
+so use the [preferred solution](../appendix/Install-on-Centos-7/#adding-selinux-security-settings).
 
 However, you can solve this the quick and dirty way by commenting out that line and then run
 

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -164,9 +164,9 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
     if (isset($aDSNInfo['username']) && $aDSNInfo['username']) {
         $sCMD .= ' -U ' . $aDSNInfo['username'];
     }
-    $procenv = null;
+    $aProcEnv = null;
     if (isset($aDSNInfo['password']) && $aDSNInfo['password']) {
-        $procenv = array_merge(array('PGPASSWORD' => $aDSNInfo['password']), $_ENV);
+        $aProcEnv = array_merge(array('PGPASSWORD' => $aDSNInfo['password']), $_ENV);
     }
     if (!$bVerbose) {
         $sCMD .= ' -q';
@@ -180,15 +180,15 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
                      2 => STDERR
                     );
     $ahPipes = null;
-    $hProcess = @proc_open($sCMD, $aDescriptors, $ahPipes, null, $procenv);
+    $hProcess = @proc_open($sCMD, $aDescriptors, $ahPipes, null, $aProcEnv);
     if (!is_resource($hProcess)) {
         fail('unable to start pgsql');
     }
 
     while (strlen($sScript)) {
-        $written = fwrite($ahPipes[0], $sScript);
-        if ($written <= 0) break;
-        $sScript = substr($sScript, $written);
+        $iWritten = fwrite($ahPipes[0], $sScript);
+        if ($iWritten <= 0) break;
+        $sScript = substr($sScript, $iWritten);
     }
     fclose($ahPipes[0]);
     $iReturn = proc_close($hProcess);
@@ -198,19 +198,19 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
 }
 
 
-function runWithEnv($cmd, $env)
+function runWithEnv($sCmd, $aEnv)
 {
-    $fds = array(0 => array('pipe', 'r'),
-                 1 => STDOUT,
-                 2 => STDERR);
-    $pipes = null;
-    $proc = @proc_open($cmd, $fds, $pipes, null, $env);
-    if (!is_resource($proc)) {
-        fail('unable to run command:' . $cmd);
+    $aFDs = array(0 => array('pipe', 'r'),
+                  1 => STDOUT,
+                  2 => STDERR);
+    $aPipes = null;
+    $hProc = @proc_open($sCmd, $aFDs, $aPipes, null, $aEnv);
+    if (!is_resource($hProc)) {
+        fail('unable to run command:' . $sCmd);
     }
 
-    fclose($pipes[0]); // no stdin
+    fclose($aPipes[0]); // no stdin
 
-    $stat = proc_close($proc);
-    return $stat;
+    $iStat = proc_close($hProc);
+    return $iStat;
 }

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -158,6 +158,16 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
     $aDSNInfo = DB::parseDSN(CONST_Database_DSN);
     if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
     $sCMD = 'psql -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'];
+    if (isset($aDSNInfo['hostspec']) && $aDSNInfo['hostspec']) {
+        $sCMD .= ' -h ' . $aDSNInfo['hostspec'];
+    }
+    if (isset($aDSNInfo['username']) && $aDSNInfo['username']) {
+        $sCMD .= ' -U ' . $aDSNInfo['username'];
+    }
+    $procenv = null;
+    if (isset($aDSNInfo['password']) && $aDSNInfo['password']) {
+        $procenv = array_merge(array('PGPASSWORD' => $aDSNInfo['password']), $_ENV);
+    }
     if (!$bVerbose) {
         $sCMD .= ' -q';
     }
@@ -170,7 +180,7 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
                      2 => STDERR
                     );
     $ahPipes = null;
-    $hProcess = @proc_open($sCMD, $aDescriptors, $ahPipes);
+    $hProcess = @proc_open($sCMD, $aDescriptors, $ahPipes, null, $procenv);
     if (!is_resource($hProcess)) {
         fail('unable to start pgsql');
     }

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -196,3 +196,21 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
         fail("pgsql returned with error code ($iReturn)");
     }
 }
+
+
+function runWithEnv($cmd, $env)
+{
+    $fds = array(0 => array('pipe', 'r'),
+                 1 => STDOUT,
+                 2 => STDERR);
+    $pipes = null;
+    $proc = @proc_open($cmd, $fds, $pipes, null, $env);
+    if (!is_resource($proc)) {
+        fail('unable to run command:' . $cmd);
+    }
+
+    fclose($pipes[0]); // no stdin
+
+    $stat = proc_close($proc);
+    return $stat;
+}

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -200,9 +200,10 @@ function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreError
 
 function runWithEnv($sCmd, $aEnv)
 {
-    $aFDs = array(0 => array('pipe', 'r'),
-                  1 => STDOUT,
-                  2 => STDERR);
+    $aFDs = array(
+             0 => array('pipe', 'r'),
+             1 => STDOUT,
+             2 => STDERR);
     $aPipes = null;
     $hProc = @proc_open($sCmd, $aFDs, $aPipes, null, $aEnv);
     if (!is_resource($hProc)) {

--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -9,6 +9,7 @@ if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 @define('CONST_Debug', false);
 @define('CONST_Database_DSN', 'pgsql://@/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
 @define('CONST_Database_Web_User', 'www-data');
+@define('CONST_Database_Module_Path', CONST_InstallPath.'/module');
 @define('CONST_Max_Word_Frequency', '50000');
 @define('CONST_Limit_Reindexing', true);
 // Restrict search languages.

--- a/sql/partition-tables.src.sql
+++ b/sql/partition-tables.src.sql
@@ -48,6 +48,7 @@ CREATE INDEX idx_search_name_-partition-_place_id ON search_name_-partition- USI
 CREATE INDEX idx_search_name_-partition-_centroid ON search_name_-partition- USING GIST (centroid) {ts:address-index};
 CREATE INDEX idx_search_name_-partition-_name_vector ON search_name_-partition- USING GIN (name_vector) WITH (fastupdate = off) {ts:address-index};
 
+DROP TABLE IF EXISTS location_road_-partition-;
 CREATE TABLE location_road_-partition- (
   place_id BIGINT,
   partition SMALLINT,

--- a/test/README.md
+++ b/test/README.md
@@ -73,6 +73,11 @@ The tests can be configured with a set of environment variables:
                    the test databases (db tests)
  * `TEST_DB` - name of test database (db tests)
  * `ABI_TEST_DB` - name of the database containing the API test data (api tests)
+ * `DB_HOST` - (optional) hostname of database host
+ * `DB_USER` - (optional) username of database login
+ * `DB_PASS` - (optional) password for database login
+ * `SERVER_MODULE_PATH` - (optional) path on the Postgres server to Nominatim
+ *                        module shared library file
  * `TEST_SETTINGS_TEMPLATE` - file to write temporary Nominatim settings to
  * `REMOVE_TEMPLATE` - if true, the template database will not be reused during
                        the next run. Reusing the base templates speeds up tests

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -953,6 +953,8 @@ function checkModulePresence()
     $sSQL = "CREATE FUNCTION nominatim_test_import_func(text) RETURNS text AS '";
     $sSQL .= $sModulePath."/nominatim.so', 'transliteration' LANGUAGE c IMMUTABLE STRICT";
     $sSQL .= ';DROP FUNCTION nominatim_test_import_func(text);';
+
+    $oDB =& getDB();
     $oResult = $oDB->query($sSQL);
 
     $bResult = true;

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -950,6 +950,7 @@ function checkModulePresence()
 {
     // Try accessing the C module, so we know early if something is wrong
     // and can simply error out.
+    global $sModulePath;
     $sSQL = "CREATE FUNCTION nominatim_test_import_func(text) RETURNS text AS '";
     $sSQL .= $sModulePath."/nominatim.so', 'transliteration' LANGUAGE c IMMUTABLE STRICT";
     $sSQL .= ';DROP FUNCTION nominatim_test_import_func(text);';

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -448,10 +448,10 @@ if ($aCMDResult['load-data'] || $aCMDResult['all']) {
             // PGSQL_EMPTY_QUERY, PGSQL_COMMAND_OK, PGSQL_TUPLES_OK,
             // PGSQL_COPY_OUT, PGSQL_COPY_IN, PGSQL_BAD_RESPONSE,
             // PGSQL_NONFATAL_ERROR and PGSQL_FATAL_ERROR
-            echo 'Query result ' . $i . ' is: ' . $resultStatus . '\n';
+            echo 'Query result ' . $i . ' is: ' . $resultStatus . "\n";
             if ($resultStatus != PGSQL_COMMAND_OK && $resultStatus != PGSQL_TUPLES_OK) {
                 $resultError = pg_result_error($hPGresult);
-                echo '-- error text ' . $i . ': ' . $resultError . '\n';
+                echo '-- error text ' . $i . ': ' . $resultError . "\n";
                 $bFailed = true;
             }
         }
@@ -634,13 +634,13 @@ if ($aCMDResult['index'] || $aCMDResult['all']) {
     }
     if (!$aCMDResult['index-noanalyse']) pgsqlRunScript('ANALYSE');
     info('Index ranks 5 - 25');
-    $iStatus = runWithEnv($sBaseCmd.' -r 5 -R 25', $procenv);
+    $iStatus = runWithEnv($sBaseCmd.' -r 5 -R 25', $aProcEnv);
     if ($iStatus != 0) {
         fail('error status ' . $iStatus . ' running nominatim!');
     }
     if (!$aCMDResult['index-noanalyse']) pgsqlRunScript('ANALYSE');
     info('Index ranks 26 - 30');
-    $iStatus = runWithEnv($sBaseCmd.' -r 26', $procenv);
+    $iStatus = runWithEnv($sBaseCmd.' -r 26', $aProcEnv);
     if ($iStatus != 0) {
         fail('error status ' . $iStatus . ' running nominatim!');
     }

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -16,7 +16,6 @@ $aCMDOptions
 
    array('osm-file', '', 0, 1, 1, 1, 'realpath', 'File to import'),
    array('threads', '', 0, 1, 1, 1, 'int', 'Number of threads (where possible)'),
-   array('module-path', '', 0, 1, 1, 1, 'string', 'Directory on Postgres server containing Nominatim module'),
 
    array('all', '', 0, 1, 0, 0, 'bool', 'Do the complete process'),
 
@@ -80,11 +79,8 @@ if (isset($aCMDResult['osm2pgsql-cache'])) {
     $iCacheMemory = getCacheMemoryMB();
 }
 
-$sModulePath = CONST_InstallPath . '/module';
-if (isset($aCMDResult['module-path'])) {
-    $sModulePath = $aCMDResult['module-path'];
-    echo 'module path: ' . $sModulePath . '\n';
-}
+$sModulePath = CONST_Database_Module_Path;
+info('module path: ' . $sModulePath);
 
 $aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -916,23 +916,6 @@ function passthruCheckReturn($cmd)
     passthru($cmd, $result);
 }
 
-function runWithEnv($cmd, $env)
-{
-    $fds = array(0 => array('pipe', 'r'),
-                 1 => STDOUT,
-                 2 => STDERR);
-    $pipes = null;
-    $proc = @proc_open($cmd, $fds, $pipes, null, $env);
-    if (!is_resource($proc)) {
-        fail('unable to run command:' . $cmd);
-    }
-
-    fclose($pipes[0]); // no stdin
-
-    $stat = proc_close($proc);
-    return $stat;
-}
-
 function replace_tablespace($sTemplate, $sTablespace, $sSql)
 {
     if ($sTablespace) {

--- a/utils/update.php
+++ b/utils/update.php
@@ -16,7 +16,7 @@ $aCMDOptions
 
    array('init-updates', '', 0, 1, 0, 0, 'bool', 'Set up database for updating'),
    array('check-for-updates', '', 0, 1, 0, 0, 'bool', 'Check if new updates are available'),
-   array('update-functions', '', 0, 1, 0, 0, 'bool', 'Update trigger functions to support differential updates'),
+   array('no-update-functions', '', 0, 1, 0, 0, 'bool', 'Do not update trigger functions to support differential updates (assuming the diff update logic is already present)'),
    array('import-osmosis', '', 0, 1, 0, 0, 'bool', 'Import updates once'),
    array('import-osmosis-all', '', 0, 1, 0, 0, 'bool', 'Import updates forever'),
    array('no-index', '', 0, 1, 0, 0, 'bool', 'Do not index the new data'),
@@ -98,10 +98,10 @@ if ($aResult['init-updates']) {
         echo "and have set up CONST_Pyosmium_Binary to point to pyosmium-get-changes.\n";
         fail('pyosmium-get-changes not found or not usable');
     }
-    if ($aResult['update-functions']) {
+    if (!$aResult['no-update-functions']) {
         $sSetup = CONST_InstallPath.'/utils/setup.php';
         $iRet = -1;
-        passthru($argv[0].' '.$sSetup.' --create-functions --enable-diff-updates', $iRet);
+        passthru($sSetup.' --create-functions --enable-diff-updates', $iRet);
         if ($iRet != 0) {
             fail('Error running setup script');
         }

--- a/utils/update.php
+++ b/utils/update.php
@@ -122,8 +122,8 @@ if ($aResult['init-updates']) {
     }
 
     pg_query($oDB->connection, 'TRUNCATE import_status');
-    $sSQL = 'INSERT INTO import_status (lastimportdate, sequence_id, indexed) VALUES(';
-    $sSQL .= "'".$sDatabaseDate."',".$aOutput[0].', true)';
+    $sSQL = "INSERT INTO import_status (lastimportdate, sequence_id, indexed) VALUES('";
+    $sSQL .= $sDatabaseDate."',".$aOutput[0].', true)';
     if (!pg_query($oDB->connection, $sSQL)) {
         fail('Could not enter sequence into database.');
     }
@@ -428,7 +428,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
             $oDB->query($sSQL);
             echo date('Y-m-d H:i:s')." Completed index step for $sBatchEnd in ".round((time()-$fCMDStartTime)/60, 2)." minutes\n";
 
-            $sSQL = 'UPDATE import_status SET indexed = true';
+            $sSQL = 'update import_status set indexed = true';
             $oDB->query($sSQL);
         }
 
@@ -436,21 +436,4 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
         echo date('Y-m-d H:i:s')." Completed all for $sBatchEnd in ".round($fDuration/60, 2)." minutes\n";
         if (!$aResult['import-osmosis-all']) exit(0);
     }
-}
-
-function runWithEnv($cmd, $env)
-{
-    $fds = array(0 => array('pipe', 'r'),
-                 1 => STDOUT,
-                 2 => STDERR);
-    $pipes = null;
-    $proc = @proc_open($cmd, $fds, $pipes, null, $env);
-    if (!is_resource($proc)) {
-        fail('unable to run command:' . $cmd);
-    }
-
-    fclose($pipes[0]); // no stdin
-
-    $stat = proc_close($proc);
-    return $stat;
 }

--- a/utils/update.php
+++ b/utils/update.php
@@ -65,9 +65,9 @@ if (isset($aDSNInfo['username']) && $aDSNInfo['username']) {
 if (isset($aDSNInfo['hostspec']) && $aDSNInfo['hostspec']) {
     $sOsm2pgsqlCmd .= ' -H ' . $aDSNInfo['hostspec'];
 }
-$procenv = null;
+$aProcEnv = null;
 if (isset($aDSNInfo['password']) && $aDSNInfo['password']) {
-    $procenv = array_merge(array('PGPASSWORD' => $aDSNInfo['password']), $_ENV);
+    $aProcEnv = array_merge(array('PGPASSWORD' => $aDSNInfo['password']), $_ENV);
 }
 
 if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {
@@ -153,7 +153,7 @@ if (isset($aResult['import-diff']) || isset($aResult['import-file'])) {
     // Import the file
     $sCMD = $sOsm2pgsqlCmd.' '.$sNextFile;
     echo $sCMD."\n";
-    $iErrorLevel = runWithEnv($sCMD, $procenv);
+    $iErrorLevel = runWithEnv($sCMD, $aProcEnv);
 
     if ($iErrorLevel) {
         fail("Error from osm2pgsql, $iErrorLevel\n");
@@ -205,7 +205,7 @@ if ($bHaveDiff) {
     // import generated change file
     $sCMD = $sOsm2pgsqlCmd.' '.$sTemporaryFile;
     echo $sCMD."\n";
-    $iErrorLevel = runWithEnv($sCMD, $procenv);
+    $iErrorLevel = runWithEnv($sCMD, $aProcEnv);
     if ($iErrorLevel) {
         fail("osm2pgsql exited with error level $iErrorLevel\n");
     }
@@ -289,15 +289,15 @@ if ($aResult['recompute-word-counts']) {
 }
 
 if ($aResult['index']) {
-    $cmd = CONST_InstallPath.'/nominatim/nominatim -i -d '.$aDSNInfo['database'].' -P '.$aDSNInfo['port'].' -t '.$aResult['index-instances'].' -r '.$aResult['index-rank'];
+    $sCmd = CONST_InstallPath.'/nominatim/nominatim -i -d '.$aDSNInfo['database'].' -P '.$aDSNInfo['port'].' -t '.$aResult['index-instances'].' -r '.$aResult['index-rank'];
     if (isset($aDSNInfo['hostspec']) && $aDSNInfo['hostspec']) {
-        $cmd .= ' -H ' . $aDSNInfo['hostspec'];
+        $sCmd .= ' -H ' . $aDSNInfo['hostspec'];
     }
     if (isset($aDSNInfo['username']) && $aDSNInfo['username']) {
-        $cmd .= ' -U ' . $aDSNInfo['username'];
+        $sCmd .= ' -U ' . $aDSNInfo['username'];
     }
 
-    runWithEnv($cmd, $procenv);
+    runWithEnv($sCmd, $aProcEnv);
 }
 
 if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
@@ -384,7 +384,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
             $fCMDStartTime = time();
             echo $sCMDImport."\n";
             unset($sJunk);
-            $iErrorLevel = runWithEnv($sCMDImport, $procenv);
+            $iErrorLevel = runWithEnv($sCMDImport, $aProcEnv);
             if ($iErrorLevel) {
                 echo "Error executing osm2pgsql: $iErrorLevel\n";
                 exit($iErrorLevel);
@@ -413,7 +413,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
             $fCMDStartTime = time();
 
             echo "$sThisIndexCmd\n";
-            $iErrorLevel = runWithEnv($sThisIndexCmd, $procenv);
+            $iErrorLevel = runWithEnv($sThisIndexCmd, $aProcEnv);
             if ($iErrorLevel) {
                 echo "Error: $iErrorLevel\n";
                 exit($iErrorLevel);


### PR DESCRIPTION
This pull request makes the changes necessary to enable the Nominatim application to run with a Postgres server located on a separate host from the PHP application.

Most of the changes are in the `setup.php` and `update.php` scripts to ensure the setup commands are executing properly against the (possibly remote) database server. I also amped up the error handling and sub-command execution logic in those scripts as a byproduct of my work.

I updated relevant documentation as necessary, and made the changes necessary to make the `behave` unit tests run successfully against a non-local database server.

(this is a much more complete implementation of the change described in #552)