### PR TITLE
Do not have postcode node appear in addresses directly

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -864,6 +864,10 @@ BEGIN
         SELECT * FROM get_postcode_rank(NEW.country_code, NEW.address->'postcode')
           INTO NEW.rank_search, NEW.rank_address;
 
+        IF NOT ST_GeometryType(NEW.geometry) IN ('ST_Polygon','ST_MultiPolygon') THEN
+            NEW.rank_address := 0;
+        END IF;
+
     ELSEIF NEW.class = 'place' THEN
       IF NEW.type in ('continent') THEN
         NEW.rank_search := 2;

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -20,3 +20,41 @@ Feature: Address computation
             | object | address | cached_rank_address |
             | W1     | W10     | 10                  |
             | W1     | W11     | 10                  |
+
+    Scenario: buildings with only addr:postcodes do not appear in the address of a way
+        Given the scene admin-areas
+        And the named places
+            | osm | class    | type           | admin | addr+postcode | geometry |
+            | R1  | boundary | administrative | 6     | 112           | :b0      |
+            | R34 | boundary | administrative | 8     | 112 DE        | :b1:E    |
+            | R4  | boundary | administrative | 10    | 112 DE 34     | :b2:N    |
+        And the named places
+            | osm | class    | type           | geometry |
+            | W93 | highway  | residential    | :w2N     |
+        And the places
+            | osm | class    | type        | addr+postcode | geometry |
+            | W22 | place    | postcode    | 445023        | :building:w2N |
+        When importing
+        Then place_addressline doesn't contain
+            | object | address  |
+            | W93    | W22      |
+
+    Scenario: postcode boundaries do appear in the address of a way
+        Given the scene admin-areas
+        And the named places
+            | osm | class    | type           | admin | addr+postcode | geometry |
+            | R1  | boundary | administrative | 6     | 112           | :b0      |
+            | R34 | boundary | administrative | 8     | 112 DE        | :b1:E    |
+        And the places
+            | osm | class    | type      | addr+postcode | geometry |
+            | R4  | place    | postcode  | 112 DE 34     | :b2:N    |
+        And the named places
+            | osm | class    | type           | geometry |
+            | W93 | highway  | residential    | :w2N     |
+        And the places
+            | osm | class    | type        | addr+postcode | geometry |
+            | W22 | place    | postcode    | 445023        | :building:w2N |
+        When importing
+        Then place_addressline contains
+            | object | address |
+            | W93    | R4      |

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -70,9 +70,9 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | postcode | country_code | rank_search | rank_address |
-         | N1     | E45 2CD  | gb           | 25          | 5 |
-         | N2     | E45 2    | gb           | 23          | 5 |
-         | N3     | Y45      | gb           | 21          | 5 |
+         | N1     | E45 2CD  | gb           | 25          | 0 |
+         | N2     | E45 2    | gb           | 23          | 0 |
+         | N3     | Y45      | gb           | 21          | 0 |
 
     Scenario: wrongly formatted GB postcodes are down-ranked
         Given the places
@@ -82,8 +82,8 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | gb           | 30          | 30 |
-         | N2     | gb           | 30          | 30 |
+         | N1     | gb           | 30          | 0 |
+         | N2     | gb           | 30          | 0 |
 
     Scenario: search and address rank for DE postcodes correctly assigned
         Given the places
@@ -95,10 +95,10 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | de           | 21          | 11 |
-         | N2     | de           | 30          | 30 |
-         | N3     | de           | 30          | 30 |
-         | N4     | de           | 30          | 30 |
+         | N1     | de           | 21          | 0 |
+         | N2     | de           | 30          | 0 |
+         | N3     | de           | 30          | 0 |
+         | N4     | de           | 30          | 0 |
 
     Scenario: search and address rank for other postcodes are correctly assigned
         Given the places
@@ -115,15 +115,15 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | ca           | 21          | 11 |
-         | N2     | ca           | 21          | 11 |
-         | N3     | ca           | 21          | 11 |
-         | N4     | ca           | 21          | 11 |
-         | N5     | ca           | 21          | 11 |
-         | N6     | ca           | 21          | 11 |
-         | N7     | ca           | 25          | 11 |
-         | N8     | ca           | 25          | 11 |
-         | N9     | ca           | 25          | 11 |
+         | N1     | ca           | 21          | 0 |
+         | N2     | ca           | 21          | 0 |
+         | N3     | ca           | 21          | 0 |
+         | N4     | ca           | 21          | 0 |
+         | N5     | ca           | 21          | 0 |
+         | N6     | ca           | 21          | 0 |
+         | N7     | ca           | 25          | 0 |
+         | N8     | ca           | 25          | 0 |
+         | N9     | ca           | 25          | 0 |
 
     Scenario: search and address ranks for places are correctly assigned
         Given the named places

--- a/test/bdd/db/import/postcodes.feature
+++ b/test/bdd/db/import/postcodes.feature
@@ -82,7 +82,7 @@ Feature: Import of postcodes
             | object | postcode  |
             | W22    | 112 DE 34 |
 
-    Scenario: Roads get postcodes from nearby buildings without other info
+    Scenario: Roads get postcodes from nearby named buildings without other info
         Given the scene admin-areas
         And the named places
             | osm | class    | type           | geometry |
@@ -90,6 +90,19 @@ Feature: Import of postcodes
         And the named places
             | osm | class    | type        | addr+postcode | geometry |
             | W22 | building | yes         | 445023        | :building:w2N |
+        When importing
+        Then placex contains
+            | object | postcode |
+            | W93    | 445023   |
+
+    Scenario: Roads get postcodes from nearby unnamed buildings without other info
+        Given the scene admin-areas
+        And the named places
+            | osm | class    | type           | geometry |
+            | W93 | highway  | residential    | :w2N     |
+        And the named places
+            | osm | class    | type        | addr+postcode | geometry |
+            | W22 | place    | postcode    | 445023        | :building:w2N |
         When importing
         Then placex contains
             | object | postcode |

--- a/test/bdd/steps/db_ops.py
+++ b/test/bdd/steps/db_ops.py
@@ -498,6 +498,21 @@ def check_place_addressline(context):
 
     context.db.commit()
 
+@then("place_addressline doesn't contain")
+def check_place_addressline_exclude(context):
+    cur = context.db.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    for row in context.table:
+        pid = NominatimID(row['object']).get_place_id(cur)
+        apid = NominatimID(row['address']).get_place_id(cur)
+        cur.execute(""" SELECT * FROM place_addressline
+                        WHERE place_id = %s AND address_place_id = %s""",
+                    (pid, apid))
+        eq_(0, cur.rowcount,
+            "Row found for place %s and address %s" % (row['object'], row['address']))
+
+    context.db.commit()
+
 @then("(?P<oid>\w+) expands to(?P<neg> no)? interpolation")
 def check_location_property_osmline(context, oid, neg):
     cur = context.db.cursor(cursor_factory=psycopg2.extras.DictCursor)


### PR DESCRIPTION
Many of the postcode nodes are actually derived from
incomplete addresses and are as such not even centroids.
Better let them only take part in the address computation
via the postcode table.