### PR TITLE
Remove country and state nodes from address computation

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -871,7 +871,11 @@ BEGIN
     ELSEIF NEW.class = 'place' THEN
       IF NEW.type in ('continent') THEN
         NEW.rank_search := 2;
-        NEW.rank_address := NEW.rank_search;
+        IF ST_GeometryType(NEW.geometry) IN ('ST_Polygon','ST_MultiPolygon') THEN
+            NEW.rank_address := NEW.rank_search;
+        ELSE
+            NEW.rank_address := 0;
+        END IF;
         NEW.country_code := NULL;
       ELSEIF NEW.type in ('sea') THEN
         NEW.rank_search := 2;
@@ -879,10 +883,18 @@ BEGIN
         NEW.country_code := NULL;
       ELSEIF NEW.type in ('country') THEN
         NEW.rank_search := 4;
-        NEW.rank_address := NEW.rank_search;
+        IF ST_GeometryType(NEW.geometry) IN ('ST_Polygon','ST_MultiPolygon') THEN
+            NEW.rank_address := NEW.rank_search;
+        ELSE
+            NEW.rank_address := 0;
+        END IF;
       ELSEIF NEW.type in ('state') THEN
         NEW.rank_search := 8;
-        NEW.rank_address := NEW.rank_search;
+        IF ST_GeometryType(NEW.geometry) IN ('ST_Polygon','ST_MultiPolygon') THEN
+            NEW.rank_address := NEW.rank_search;
+        ELSE
+            NEW.rank_address := 0;
+        END IF;
       ELSEIF NEW.type in ('region') THEN
         NEW.rank_search := 18; -- dropped from previous value of 10
         NEW.rank_address := 0; -- So badly miss-used that better to just drop it!

--- a/test/bdd/api/search/params.feature
+++ b/test/bdd/api/search/params.feature
@@ -51,7 +51,7 @@ Feature: Search queries
           | en |
         Then results contain
           | display_name |
-          | Plei Ya Rê, Kon Tum province, Vietnam |
+          | Plei Ya Rê, Vietnam |
 
     Scenario: Address details with unknown class types
         When sending json search query "Hundeauslauf, Hamburg" with address

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -25,7 +25,6 @@ Feature: Search queries
           | suburb       | Eilbek |
           | postcode     | 22089 |
           | city_district | Wandsbek |
-          | state        | Hamburg |
           | country      | Deutschland |
           | country_code | de |
 
@@ -40,7 +39,6 @@ Feature: Search queries
           | suburb       | Eilbek |
           | postcode     | 22089 |
           | city_district | Wandsbek |
-          | state        | Hamburg |
           | country      | Deutschland |
           | country_code | de |
 

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -168,10 +168,10 @@ Feature: Import into placex
           | object | rank_search | rank_address |
           | N1     | 30          | 30 |
           | N11    | 30          | 30 |
-          | N12    | 2           | 2 |
+          | N12    | 2           | 0 |
           | N13    | 2           | 0 |
-          | N14    | 4           | 4 |
-          | N15    | 8           | 8 |
+          | N14    | 4           | 0 |
+          | N15    | 8           | 0 |
           | N16    | 18          | 0 |
           | N17    | 12          | 12 |
           | N18    | 16          | 16 |
@@ -211,6 +211,10 @@ Feature: Import into placex
           | R21 | boundary | administrative | 32    | (3 3, 4 4, 3 4, 3 3) |
           | R22 | boundary | nature_park    | 6     | (0 0, 1 0, 0 1, 0 0) |
           | R23 | boundary | natural_reserve| 10    | (0 0, 1 1, 1 0, 0 0) |
+        And the named places
+          | osm | class | type    | geometry |
+          | R40 | place | country | (1 1, 2 2, 1 2, 1 1) |
+          | R41 | place | state   | (3 3, 4 4, 3 4, 3 3) |
         When importing
         Then placex has no entry for N1
         And placex has no entry for W10
@@ -220,6 +224,8 @@ Feature: Import into placex
           | R21    | 30          | 30 |
           | R22    | 12          | 0 |
           | R23    | 20          | 0 |
+          | R40    | 4           | 4 |
+          | R41    | 8           | 8 |
 
     Scenario: search and address ranks for highways correctly assigned
         Given the scene roads-with-pois


### PR DESCRIPTION
OSM has by now almost complete coverage of admin
boundaries up to state level. Place nodes will do more
harm than good in this case.