### PR TITLE
PHP code style: use long array syntax

### DIFF
--- a/lib/template/address-geocodejson.php
+++ b/lib/template/address-geocodejson.php
@@ -76,6 +76,6 @@ if (empty($aPlace)) {
                                            'licence' => 'ODbL',
                                            'query' => $sQuery
                                           ),
-                           'features' => [$aFilteredPlaces]
+                           'features' => array($aFilteredPlaces)
                           ));
 }


### PR DESCRIPTION
Fixes PHPCS error `Short array syntax is not allowed` 