### PR TITLE
use namespaces for PHPUnit classes

### DIFF
--- a/test/php/Nominatim/DebugTest.php
+++ b/test/php/Nominatim/DebugTest.php
@@ -6,7 +6,7 @@ use Exception;
 
 require_once('../../lib/DebugHtml.php');
 
-class DebugTest extends \PHPUnit_Framework_TestCase
+class DebugTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -5,7 +5,7 @@ namespace Nominatim;
 require_once '../../lib/lib.php';
 require_once '../../lib/ClassTypes.php';
 
-class LibTest extends \PHPUnit_Framework_TestCase
+class LibTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetClassTypesWithImportance()
     {

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -12,7 +12,7 @@ function userError($sError)
     throw new Exception($sError);
 }
 
-class ParameterParserTest extends \PHPUnit_Framework_TestCase
+class ParameterParserTest extends \PHPUnit\Framework\TestCase
 {
 
 

--- a/test/php/Nominatim/PhraseTest.php
+++ b/test/php/Nominatim/PhraseTest.php
@@ -4,7 +4,7 @@ namespace Nominatim;
 
 require_once '../../lib/Phrase.php';
 
-class PhraseTest extends \PHPUnit_Framework_TestCase
+class PhraseTest extends \PHPUnit\Framework\TestCase
 {
 
 

--- a/test/php/Nominatim/SearchContextTest.php
+++ b/test/php/Nominatim/SearchContextTest.php
@@ -6,7 +6,7 @@ namespace Nominatim;
 
 require_once '../../lib/SearchContext.php';
 
-class SearchContextTest extends \PHPUnit_Framework_TestCase
+class SearchContextTest extends \PHPUnit\Framework\TestCase
 {
     private $oCtx;
 

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -7,7 +7,7 @@ require_once('DB.php');
 
 use Exception;
 
-class StatusTest extends \PHPUnit_Framework_TestCase
+class StatusTest extends \PHPUnit\Framework\TestCase
 {
 
 

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -8,7 +8,7 @@ require_once '../../lib/db.php';
 require_once '../../lib/cmd.php';
 require_once '../../lib/TokenList.php';
 
-class TokenTest extends \PHPUnit_Framework_TestCase
+class TokenTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {


### PR DESCRIPTION
This is mandatory for PHPUnit 6.x. Older versions provide a
forward compatibility layer, so we should be good.

Fixes #1150.