### PR TITLE
make PHP testsuite work with PHPUnit6

### DIFF
--- a/test/php/Nominatim/DebugTest.php
+++ b/test/php/Nominatim/DebugTest.php
@@ -2,19 +2,23 @@
 
 namespace Nominatim;
 
-use Exception;
-
-require_once('../../lib/DebugHtml.php');
+require_once(CONST_BasePath.'/lib/DebugHtml.php');
 
 class DebugTest extends \PHPUnit\Framework\TestCase
 {
+
     protected function setUp()
     {
-        $this->oWithDebuginfo = $this->getMock(Geocode::class, array('debugInfo'));
+        $this->oWithDebuginfo = $this->getMockBuilder(\GeococdeMock::class)
+                                    ->setMethods(array('debugInfo'))
+                                    ->getMock();
         $this->oWithDebuginfo->method('debugInfo')
                   ->willReturn(array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3'));
 
-        $this->oWithToString = $this->getMock(Geocode::class, array('__toString'));
+
+        $this->oWithToString = $this->getMockBuilder(\SomeMock::class)
+                                    ->setMethods(array('__toString'))
+                                    ->getMock();
         $this->oWithToString->method('__toString')->willReturn('me as string');
     }
 

--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -2,8 +2,7 @@
 
 namespace Nominatim;
 
-require_once '../../lib/lib.php';
-require_once '../../lib/ClassTypes.php';
+require_once(CONST_BasePath.'/lib/ClassTypes.php');
 
 class LibTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -2,14 +2,12 @@
 
 namespace Nominatim;
 
-use Exception;
-
-require_once('../../lib/ParameterParser.php');
+require_once(CONST_BasePath.'/lib/ParameterParser.php');
 
 
 function userError($sError)
 {
-    throw new Exception($sError);
+    throw new \Exception($sError);
 }
 
 class ParameterParserTest extends \PHPUnit\Framework\TestCase
@@ -55,14 +53,18 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
 
     public function testGetIntWithNonNumber()
     {
-        $this->setExpectedException(Exception::class, "Integer number expected for parameter 'int4'");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Integer number expected for parameter 'int4'");
+
         (new ParameterParser(array('int4' => 'a')))->getInt('int4');
     }
 
 
     public function testGetIntWithEmpytString()
     {
-        $this->setExpectedException(Exception::class, "Integer number expected for parameter 'int5'");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Integer number expected for parameter 'int5'");
+
         (new ParameterParser(array('int5' => '')))->getInt('int5');
     }
 
@@ -85,20 +87,26 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
 
     public function testGetFloatWithEmptyString()
     {
-        $this->setExpectedException(Exception::class, "Floating-point number expected for parameter 'float4'");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Floating-point number expected for parameter 'float4'");
+
         (new ParameterParser(array('float4' => '')))->getFloat('float4');
     }
 
     public function testGetFloatWithTextString()
     {
-        $this->setExpectedException(Exception::class, "Floating-point number expected for parameter 'float5'");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Floating-point number expected for parameter 'float5'");
+
         (new ParameterParser(array('float5' => 'a')))->getFloat('float5');
     }
 
 
     public function testGetFloatWithInvalidNumber()
     {
-        $this->setExpectedException(Exception::class, "Floating-point number expected for parameter 'float6'");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Floating-point number expected for parameter 'float6'");
+
         (new ParameterParser(array('float6' => '-55.')))->getFloat('float6');
     }
 
@@ -138,7 +146,9 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSetWithValueNotInSet()
     {
-        $this->setExpectedException(Exception::class, "Parameter 'val4' must be one of: foo, bar");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Parameter 'val4' must be one of: foo, bar");
+
         (new ParameterParser(array('val4' => 'faz')))->getSet('val4', array('foo', 'bar'));
     }
 

--- a/test/php/Nominatim/PhraseTest.php
+++ b/test/php/Nominatim/PhraseTest.php
@@ -2,7 +2,7 @@
 
 namespace Nominatim;
 
-require_once '../../lib/Phrase.php';
+require_once(CONST_BasePath.'/lib/Phrase.php');
 
 class PhraseTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/php/Nominatim/SearchContextTest.php
+++ b/test/php/Nominatim/SearchContextTest.php
@@ -2,9 +2,7 @@
 
 namespace Nominatim;
 
-@define('CONST_BasePath', '../../');
-
-require_once '../../lib/SearchContext.php';
+require_once(CONST_BasePath.'/lib/SearchContext.php');
 
 class SearchContextTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -2,18 +2,17 @@
 
 namespace Nominatim;
 
-require_once('../../lib/Status.php');
-require_once('DB.php');
+require_once(CONST_BasePath.'/lib/Status.php');
 
-use Exception;
 
 class StatusTest extends \PHPUnit\Framework\TestCase
 {
 
-
     public function testNoDatabaseGiven()
     {
-        $this->setExpectedException(Exception::class, 'No database', 700);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No database');
+        $this->expectExceptionCode(700);
 
         $oDB = null;
         $oStatus = new Status($oDB);
@@ -22,7 +21,9 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testNoDatabaseConnectionFail()
     {
-        $this->setExpectedException(Exception::class, 'No database', 700);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No database');
+        $this->expectExceptionCode(700);
 
         // causes 'Non-static method should not be called statically, assuming $this from incompatible context'
         // failure on travis
@@ -40,10 +41,14 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testModuleFail()
     {
-        $this->setExpectedException(Exception::class, 'Module call failed', 702);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Module call failed');
+        $this->expectExceptionCode(702);
 
         // stub has getOne method but doesn't return anything
-        $oDbStub = $this->getMock(\DB::class, array('getOne'));
+        $oDbStub = $this->getMockBuilder(\DB::class)
+                        ->setMethods(array('getOne'))
+                        ->getMock();
 
         $oStatus = new Status($oDbStub);
         $this->assertNull($oStatus->status());
@@ -52,9 +57,13 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testWordIdQueryFail()
     {
-        $this->setExpectedException(Exception::class, 'No value', 704);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No value');
+        $this->expectExceptionCode(704);
 
-        $oDbStub = $this->getMock(\DB::class, array('getOne'));
+        $oDbStub = $this->getMockBuilder(\DB::class)
+                        ->setMethods(array('getOne'))
+                        ->getMock();
 
         // return no word_id
         $oDbStub->method('getOne')
@@ -70,7 +79,9 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testOK()
     {
-        $oDbStub = $this->getMock(\DB::class, array('getOne'));
+        $oDbStub = $this->getMockBuilder(\DB::class)
+                        ->setMethods(array('getOne'))
+                        ->getMock();
 
         $oDbStub->method('getOne')
                 ->will($this->returnCallback(function ($sql) {
@@ -84,7 +95,9 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testDataDate()
     {
-        $oDbStub = $this->getMock(\DB::class, array('getOne'));
+        $oDbStub = $this->getMockBuilder(\DB::class)
+                        ->setMethods(array('getOne'))
+                        ->getMock();
      
         $oDbStub->method('getOne')
                 ->willReturn(1519430221);

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -2,17 +2,18 @@
 
 namespace Nominatim;
 
-@define('CONST_BasePath', '../../');
+require_once(CONST_BasePath.'/lib/db.php');
+require_once(CONST_BasePath.'/lib/cmd.php');
+require_once(CONST_BasePath.'/lib/TokenList.php');
 
-require_once '../../lib/db.php';
-require_once '../../lib/cmd.php';
-require_once '../../lib/TokenList.php';
 
 class TokenTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {
-        $this->oNormalizer = $this->getMock(\MockNormalizer::class, array('transliterate'));
+        $this->oNormalizer = $this->getMockBuilder(\MockNormalizer::class)
+                                  ->setMethods(array('transliterate'))
+                                  ->getMock();
         $this->oNormalizer->method('transliterate')
                           ->will($this->returnCallback(function ($text) {
                               return strtolower($text);
@@ -55,7 +56,9 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectOutputRegex('/<p><tt>/');
 
-        $oDbStub = $this->getMock(\DB::class, array('getAll'));
+        $oDbStub = $this->getMockBuilder(\DB::class)
+                        ->setMethods(array('getAll'))
+                        ->getMock();
         $oDbStub->method('getAll')
                 ->will($this->returnCallback(function ($sql) {
                     $aResults = array();

--- a/test/php/bootstrap.php
+++ b/test/php/bootstrap.php
@@ -1,1 +1,2 @@
 <?php
+    @define('CONST_BasePath', '../..');

--- a/test/php/phpunit.xml
+++ b/test/php/phpunit.xml
@@ -8,13 +8,14 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="true"
-    bootstrap="test/php/bootstrap.php"
+    bootstrap="./bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="true"
     >
     <php>
     </php>
     <testsuites>
         <testsuite name="Nominatim PHP Test Suite">
-            <directory>./test/php/Nominatim</directory>
+            <directory>./Nominatim</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Works in PHPUnit 6.5 (default on Ubuntu 18) and PHPUnit 5.7 (default on Travis)

* get rid of deprecation warnings when running PHP tests in Travis (see https://travis-ci.org/openstreetmap/Nominatim/jobs/428937492)
* use newer Exception testing syntax
* move `phpunit.xml` into `tests/php/` because that's where usually the tests are run, otherwise the file would get ignored
* define `CONST_Basepath` in `bootstrap.php` which helps when one tested module calls the next