### PR TITLE
Set exception handler by request format

### DIFF
--- a/lib/DatabaseError.php
+++ b/lib/DatabaseError.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Nominatim;
+
+class DatabaseError extends \Exception
+{
+
+    public function __construct($message, $code = 500, Exception $previous = null, $oSql)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->oSql = $oSql;
+    }
+
+    public function __toString()
+    {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+
+    public function getSqlError()
+    {
+        return $this->oSql->getMessage();
+    }
+
+    public function getSqlDebugDump()
+    {
+        if (CONST_Debug) {
+            return var_export($this->oSql, true);
+        } else {
+            return $this->oSql->getUserInfo();
+        }
+    }
+}

--- a/lib/template/error-html.php
+++ b/lib/template/error-html.php
@@ -1,0 +1,61 @@
+<?php
+
+    $title = 'Internal Server Error';
+    if ( $exception->getCode() == 400 ) {
+        $title = 'Bad Request';
+    }
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        em { font-weight: bold; font-family: monospace; color: #e00404; background-color: #ffeaea; }
+    </style>
+</head>
+<body>
+    <h1><?php echo $title ?></h1>
+    
+    <?php if (get_class($exception) == 'Nominatim\DatabaseError') { ?>
+
+        <p>Nominatim has encountered an internal error while accessing the database.
+           This may happen because the database is broken or because of a bug in
+           the software.</p>
+
+    <?php } else { ?>
+
+        <p>Nominatim has encountered an error with your request.</p>
+
+    <?php } ?>
+
+
+    <h3>Details</h3>
+
+    Uncaught exception <em><?php echo get_class($exception) ?></em>
+    with message <em><?php echo $exception->getMessage() ?></em>
+
+    <?php if (CONST_Debug) { ?>
+        <br>
+        thrown in <em><?php $exception->getFile() . '('. $exception->getLine() . ')' ?></em>.
+
+        <?php if (get_class($exception) == 'Nominatim\DatabaseError') { ?>
+
+            <h3>SQL Error</h3>
+            <em><?php echo $exception->getSqlError() ?></em>
+
+            <pre><?php echo $exception->getSqlDebugDump() ?></pre>
+
+        <?php } ?>
+
+        <h3>Stack trace</h3>
+        <pre><?php echo $exception->getTraceAsString() ?></pre>
+
+    <?php } ?>
+
+    <p>
+        If you feel this error is incorrect feel file an issue on
+        <a href="https://github.com/openstreetmap/Nominatim/issues">Github</a>.
+
+        Please include the error message above and the URL you used.
+    </p>
+</body>
+</html>

--- a/lib/template/error-json.php
+++ b/lib/template/error-json.php
@@ -1,0 +1,11 @@
+<?php
+    $error = array(
+              'code' => $exception->getCode(),
+              'message' => $exception->getMessage()
+    );
+
+    if (CONST_Debug) {
+        $error['details'] = $exception->getFile() . '('. $exception->getLine() . ')';
+    }
+
+    echo javascript_renderData(array('error' => $error));

--- a/lib/template/error-xml.php
+++ b/lib/template/error-xml.php
@@ -1,0 +1,7 @@
+<error>
+    <code><?php echo $exception->getCode() ?></code>
+    <message><?php echo $exception->getMessage() ?></message>
+    <?php if (CONST_Debug) { ?>
+    <details><?php echo $exception->getFile() . '('. $exception->getLine() . ')' ?></details>
+    <?php } ?>
+</error>

--- a/test/bdd/api/errors/formats.feature
+++ b/test/bdd/api/errors/formats.feature
@@ -1,0 +1,13 @@
+@APIDB
+Feature: Places by osm_type and osm_id Tests
+    Simple tests for errors in various response formats.
+
+    Scenario Outline: Force error by providing too many ids
+        When sending <format> lookup query for N1,N2,N3,N4,N5,N6,N7,N8,N9,N10,N11,N12,N13,N14,N15,N16,N17,N18,N19,N20,N21,N22,N23,N24,N25,N26,N27,N28,N29,N30,N31,N32,N33,N34,N35,N36,N37,N38,N39,N40,N41,N42,N43,N44,N45,N46,N47,N48,N49,N50,N51
+        Then a <format> user error is returned
+
+    Examples:
+        | format  |
+        | xml     |
+        | json    |
+        | geojson |

--- a/test/bdd/api/lookup/simple.feature
+++ b/test/bdd/api/lookup/simple.feature
@@ -1,6 +1,6 @@
 @APIDB
 Feature: Places by osm_type and osm_id Tests
-    Simple tests for internal server errors and response format.
+    Simple tests for response format.
 
     Scenario Outline: address lookup for existing node, way, relation
         When sending <format> lookup query for N3284625766,W6065798,,R123924,X99,N0

--- a/test/bdd/api/search/simple.feature
+++ b/test/bdd/api/search/simple.feature
@@ -194,7 +194,7 @@ Feature: Simple Tests
         When sending json search query "Tokyo"
             | param        | value |
             |json_callback | <data> |
-        Then a HTTP 400 is returned
+        Then a json user error is returned
 
     Examples:
       | data |

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -494,6 +494,18 @@ def step_impl(context, fmt):
     context.execute_steps("Then a HTTP 200 is returned")
     eq_(context.response.format, fmt)
 
+@then(u'a (?P<fmt>\w+) user error is returned')
+def check_page_error(context, fmt):
+    context.execute_steps("Then a HTTP 400 is returned")
+    eq_(context.response.format, fmt)
+
+    if fmt == 'html':
+        assert_is_not_none(re.search(r'<html( |>).+</html>', context.response.page, re.DOTALL))
+    elif fmt == 'xml':
+        assert_is_not_none(re.search(r'<error>.+</error>', context.response.page, re.DOTALL))
+    else:
+        assert_is_not_none(re.search(r'({"error":)', context.response.page, re.DOTALL))
+
 @then(u'result header contains')
 def check_header_attr(context):
     for line in context.table:

--- a/test/php/Nominatim/AddressDetailsTest.php
+++ b/test/php/Nominatim/AddressDetailsTest.php
@@ -2,13 +2,9 @@
 
 namespace Nominatim;
 
+require_once(CONST_BasePath.'/lib/init-website.php');
 require_once(CONST_BasePath.'/lib/AddressDetails.php');
 
-
-function chksql($oSql, $sMsg = 'Database request failed')
-{
-    return $oSql;
-}
 
 class AddressDetailsTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/php/Nominatim/DatabaseErrorTest.php
+++ b/test/php/Nominatim/DatabaseErrorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nominatim;
+
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/DatabaseError.php');
+
+class DatabaseErrorTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testSqlMessage()
+    {
+        $oSqlStub = $this->getMockBuilder(\DB_Error::class)
+                    ->setMethods(array('getMessage'))
+                    ->getMock();
+
+        $oSqlStub->method('getMessage')
+                ->willReturn('Unknown table.');
+
+        $oErr = new DatabaseError('Sql error', 123, null, $oSqlStub);
+        $this->assertEquals('Sql error', $oErr->getMessage());
+        $this->assertEquals(123, $oErr->getCode());
+        $this->assertEquals('Unknown table.', $oErr->getSqlError());
+
+        // causes a circular reference warning during dump
+        // $this->assertRegExp('/Mock_DB_Error/', $oErr->getSqlDebugDump());
+    }
+
+    public function testSqlObjectDump()
+    {
+        $oErr = new DatabaseError('Sql error', 123, null, array('one' => 'two'));
+        $this->assertRegExp('/two/', $oErr->getSqlDebugDump());
+    }
+
+    public function testChksqlThrows()
+    {
+        $this->expectException(DatabaseError::class);
+        $this->expectExceptionMessage('My custom error message');
+        $this->expectExceptionCode(500);
+
+        $oDB = new \DB_Error;
+        $this->assertEquals(false, chksql($oDB, 'My custom error message'));
+    }
+}

--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -2,6 +2,9 @@
 
 namespace Nominatim;
 
+require_once(CONST_BasePath.'/lib/lib.php');
+require_once(CONST_BasePath.'/lib/ClassTypes.php');
+
 class LibTest extends \PHPUnit\Framework\TestCase
 {
 

--- a/test/php/Nominatim/StatusTest.php
+++ b/test/php/Nominatim/StatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Nominatim;
 
+require_once(CONST_BasePath.'/lib/db.php');
 require_once(CONST_BasePath.'/lib/Status.php');
 
 

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -2,8 +2,8 @@
 
 namespace Nominatim;
 
-require_once(CONST_BasePath.'/lib/db.php');
-require_once(CONST_BasePath.'/lib/cmd.php');
+// require_once(CONST_BasePath.'/lib/db.php');
+// require_once(CONST_BasePath.'/lib/cmd.php');
 require_once(CONST_BasePath.'/lib/TokenList.php');
 
 

--- a/test/php/bootstrap.php
+++ b/test/php/bootstrap.php
@@ -1,2 +1,4 @@
 <?php
     @define('CONST_BasePath', '../..');
+    @define('CONST_Debug', true);
+    @define('CONST_NoAccessControl', false);

--- a/website/details.php
+++ b/website/details.php
@@ -11,6 +11,7 @@ ini_set('memory_limit', '200M');
 $oParams = new Nominatim\ParameterParser();
 
 $sOutputFormat = $oParams->getSet('format', array('html', 'json'), 'html');
+set_exception_handler_by_format($sOutputFormat);
 
 $aLangPrefOrder = $oParams->getPreferredLanguages();
 $sLanguagePrefArraySQL = 'ARRAY['.join(',', array_map('getDBQuoted', $aLangPrefOrder)).']';

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -12,6 +12,7 @@ $oParams = new Nominatim\ParameterParser();
 
 // Format for output
 $sOutputFormat = $oParams->getSet('format', array('xml', 'json', 'geojson'), 'xml');
+set_exception_handler_by_format($sOutputFormat);
 
 // Preferred language
 $aLangPrefOrder = $oParams->getPreferredLanguages();

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -13,6 +13,7 @@ $oParams = new Nominatim\ParameterParser();
 
 // Format for output
 $sOutputFormat = $oParams->getSet('format', array('html', 'xml', 'json', 'jsonv2', 'geojson', 'geocodejson'), 'xml');
+set_exception_handler_by_format($sOutputFormat);
 
 // Preferred language
 $aLangPrefOrder = $oParams->getPreferredLanguages();

--- a/website/search.php
+++ b/website/search.php
@@ -27,6 +27,7 @@ if (CONST_Search_ReversePlanForAll
 
 // Format for output
 $sOutputFormat = $oParams->getSet('format', array('html', 'xml', 'json', 'jsonv2', 'geojson', 'geocodejson'), 'html');
+set_exception_handler_by_format($sOutputFormat);
 
 $sForcedGeometry = ($sOutputFormat == 'html') ? 'geojson' : null;
 $oGeocode->loadParamArray($oParams, $sForcedGeometry);


### PR DESCRIPTION
For https://github.com/openstreetmap/Nominatim/issues/947

- catch any unhandled exceptions in `init-website.php`, convert existing exit() logic to use exceptions
- allow setting exception handler format (JSON, XML). Only works after an endpoint has parsed the format from the URL. Alternative would be to examine `$_GET` but we have some legacy default formats, e.g. `/reverse` it's `json`
- move exception content into template files
- new `Nominatim::DatabaseError`, a subclass which can store a SQL result object. I didn't want to write a generic `Nominatim::Error` (yet)
- depends on https://github.com/openstreetmap/Nominatim/pull/1180

For the future
- The exception handling in the status endpoint uses custom error codes (`7xx`) and should be adapted, e.g. a new exception subclass
- BDD tests could parse the error message from HTML/JSON/XML. I started but it soon got too complex
- Unclear how much extra content should go into the JSON/XML output. The HTML output has the most details, e.g. link to github repository
- While running `phpunit .` finished fine, running individual files require more module imports (`require_once(...`). Once I add that the `phpunit .` complains about `Cannot redeclare chksql()`. More OO and classes in the future can solve this
