### PR TITLE
Phrase splitting: treat multiple spaces like one

### DIFF
--- a/lib/Phrase.php
+++ b/lib/Phrase.php
@@ -23,7 +23,7 @@ class Phrase
 
     public function __construct($sPhrase, $sPhraseType)
     {
-        $this->sPhrase = trim($sPhrase);
+        $this->sPhrase = preg_replace('/  +/', ' ', trim($sPhrase));
         $this->sPhraseType = $sPhraseType;
         $this->aWords = explode(' ', $this->sPhrase);
         $this->aWordSets = $this->createWordSets($this->aWords, 0);

--- a/test/php/Nominatim/PhraseTest.php
+++ b/test/php/Nominatim/PhraseTest.php
@@ -48,6 +48,14 @@ class PhraseTest extends \PHPUnit\Framework\TestCase
             $this->serializeSets($oPhrase->getWordSets())
         );
 
+        # trailing and multiple spaces are removed
+        $oPhrase = new Phrase('  a     b  ', '');
+        $this->assertEquals(
+            '(a b),(a|b)',
+            $this->serializeSets($oPhrase->getWordSets())
+        );
+
+
         $oPhrase = new Phrase('a b c', '');
         $this->assertEquals(
             '(a b c),(a|b c),(a|b|c),(a b|c)',


### PR DESCRIPTION
`new Phrase('a   b', '');` creates 8 word sets (`(a   b),(a|  b),(a|| b),(a|||b),(a||b),(a | b),(a ||b),(a  |b)`), `new Phrase('a     b', '');` even 32. With this change it's only two (`(a b),(a|b)`).

While I think more word sets won't make a different further down the search logic (either being trimmed, ignored or database returning no results for the word set) more wordsets consume unnecessary memory.