### PR TITLE
adjust BDD api test cases to 2018 test database

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -72,12 +72,12 @@ The tests can be configured with a set of environment variables:
  * `TEMPLATE_DB` - name of template database used as a skeleton for
                    the test databases (db tests)
  * `TEST_DB` - name of test database (db tests)
- * `ABI_TEST_DB` - name of the database containing the API test data (api tests)
+ * `API_TEST_DB` - name of the database containing the API test data (api tests)
  * `DB_HOST` - (optional) hostname of database host
  * `DB_USER` - (optional) username of database login
  * `DB_PASS` - (optional) password for database login
  * `SERVER_MODULE_PATH` - (optional) path on the Postgres server to Nominatim
- *                        module shared library file
+                          module shared library file
  * `TEST_SETTINGS_TEMPLATE` - file to write temporary Nominatim settings to
  * `REMOVE_TEMPLATE` - if true, the template database will not be reused during
                        the next run. Reusing the base templates speeds up tests
@@ -117,8 +117,8 @@ planets are likely to work as well but you may see isolated test
 failures where the data has changed. To recreate the input data
 for the test database run:
 
-    wget https://free.nchc.org.tw/osm.planet/pbf/planet-160725.osm.pbf
-    osmconvert planet-160725.osm.pbf -B=test/testdb/testdb.polys -o=testdb.pbf
+    wget https://ftp5.gwdg.de/pub/misc/openstreetmap/planet.openstreetmap.org/pbf/planet-180924.osm.pbf
+    osmconvert planet-180924.osm.pbf -B=test/testdb/testdb.polys -o=testdb.pbf
 
 Before importing make sure to add the following to your local settings:
 

--- a/test/bdd/api/reverse/language.feature
+++ b/test/bdd/api/reverse/language.feature
@@ -5,7 +5,7 @@ Feature: Localization of reverse search results
         When sending json reverse coordinates 18.1147,-15.95
         Then result addresses contain
           | ID | country |
-          | 0  | Mauritanie موريتانيا |
+          | 0  | موريتانيا |
 
     Scenario: accept-language parameter
         When sending json reverse coordinates 18.1147,-15.95

--- a/test/bdd/api/reverse/queries.feature
+++ b/test/bdd/api/reverse/queries.feature
@@ -31,7 +31,7 @@ Feature: Reverse geocoding
           | way      | place    | house |
         And result addresses contain
           | house_number | road |
-          | 1410         | Juan Antonio Lavalleja |
+          | 1416         | Juan Antonio Lavalleja |
 
     Scenario: Address with non-numerical house number
         When sending jsonv2 reverse coordinates 53.579805460944,9.9475670458196
@@ -50,7 +50,7 @@ Feature: Reverse geocoding
         When sending jsonv2 reverse coordinates 54.046489113,8.5546870529
         Then results contain
          | display_name |
-         | Freie und Hansestadt Hamburg, Deutschland |
+         | Hamburg, Deutschland |
 
     Scenario: When slightly outside town, the town is not shown
         When sending jsonv2 reverse coordinates -32.122,-56.114

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -19,30 +19,32 @@ Feature: Search queries
           | accept-language |
           | de |
         Then address of result 0 is
-          | type         | value |
-          | house_number | 86 |
-          | road         | Schellingstraße |
-          | suburb       | Eilbek |
-          | postcode     | 22089 |
+          | type          | value |
+          | house_number  | 86 |
+          | road          | Schellingstraße |
+          | neighbourhood | Auenviertel |
+          | suburb        | Eilbek |
+          | postcode      | 22089 |
           | city_district | Wandsbek |
-          | state        | Hamburg |
-          | country      | Deutschland |
-          | country_code | de |
+          | state         | Hamburg |
+          | country       | Deutschland |
+          | country_code  | de |
 
     Scenario: House number interpolation odd
         When sending json search query "Schellingstr 73, Hamburg" with address
           | accept-language |
           | de |
         Then address of result 0 is
-          | type         | value |
-          | house_number | 73 |
-          | road         | Schellingstraße |
-          | suburb       | Eilbek |
-          | postcode     | 22089 |
+          | type          | value |
+          | house_number  | 73 |
+          | road          | Schellingstraße |
+          | neighbourhood | Auenviertel |
+          | suburb        | Eilbek |
+          | postcode      | 22089 |
           | city_district | Wandsbek |
-          | state        | Hamburg |
-          | country      | Deutschland |
-          | country_code | de |
+          | state         | Hamburg |
+          | country       | Deutschland |
+          | country_code  | de |
 
     Scenario: With missing housenumber search falls back to road
         When sending json search query "342 rocha, santa lucia" with address


### PR DESCRIPTION
I updated the testdb PDF extract, you can fetch it from https://downloads.opencagedata.com/public/nominatim-testdb-201809.pbf

Nice to see tests needed only few changes.