### PR TITLE
support additional PostgreSQL and PostGIS versions

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -31,13 +31,13 @@ function getArraySQL($a)
 function getPostgresVersion(&$oDB)
 {
     $sVersionString = $oDB->getOne('select version()');
-    preg_match('#PostgreSQL ([0-9]+)[.]([0-9]+)[^0-9]#', $sVersionString, $aMatches);
+    preg_match('#PostgreSQL ([0-9]+)[a-z]*\.?([0-9]+)?\w?[0-9]?#', $sVersionString, $aMatches);
     return (float) ($aMatches[1].'.'.$aMatches[2]);
 }
 
 function getPostgisVersion(&$oDB)
 {
     $sVersionString = $oDB->getOne('select postgis_full_version()');
-    preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)( r([0-9]+))?"#', $sVersionString, $aMatches);
+    preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)[a-z]*[0-9]?( r([0-9]+))?"#', $sVersionString, $aMatches);
     return (float) ($aMatches[1].'.'.$aMatches[2]);
 }


### PR DESCRIPTION
Have tested this with next versions:

PostgreSQL 11beta3 (Debian 11~beta3-1.pgdg90+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit

and

POSTGIS="2.5.0rc1 r16698" [EXTENSION] PGSQL="110" GEOS="3.7.0rc1-CAPI-1.11.0 49f66217" PROJ="Rel. 4.9.3, 15 August 2016" GDAL="GDAL 2.1.2, released 2016/10/24" LIBXM
L="2.9.4" LIBJSON="0.12.1" TOPOLOGY RASTER
