### PR TITLE
enabling Universe repository

### DIFF
--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -19,6 +19,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
 #
 
 #DOCS:    :::sh
+    sudo add-apt-repository universe
     sudo apt-get -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" --force-yes -fuy install grub-pc #DOCS:
     sudo apt-get update -qq
 


### PR DESCRIPTION
on previous versions of Bionic, the Universe repository isn't enabled by default.
see [Only "main" component enabled after install](https://bugs.launchpad.net/subiquity/+bug/1783129)