### PR TITLE
new Phrase::MAX_SETS to limit memory use

### DIFF
--- a/lib/Phrase.php
+++ b/lib/Phrase.php
@@ -10,6 +10,7 @@ namespace Nominatim;
 class Phrase
 {
     const MAX_DEPTH = 7;
+    const MAX_SETS = 100000;
 
     // Complete phrase as a string.
     private $sPhrase;
@@ -23,7 +24,7 @@ class Phrase
 
     public function __construct($sPhrase, $sPhraseType)
     {
-        $this->sPhrase = trim($sPhrase);
+        $this->sPhrase = $sPhrase;
         $this->sPhraseType = $sPhraseType;
         $this->aWords = explode(' ', $this->sPhrase);
         $this->aWordSets = $this->createWordSets($this->aWords, 0);
@@ -83,7 +84,7 @@ class Phrase
         $aResult = array(array(join(' ', $aWords)));
         $sFirstToken = '';
         if ($iDepth < Phrase::MAX_DEPTH) {
-            while (count($aWords) > 1) {
+            while (count($aWords) > 1 && count($aResult) < Phrase::MAX_SETS) {
                 $sWord = array_shift($aWords);
                 $sFirstToken .= ($sFirstToken?' ':'').$sWord;
                 $aRest = $this->createWordSets($aWords, $iDepth + 1);
@@ -101,7 +102,7 @@ class Phrase
         $aResult = array(array(join(' ', $aWords)));
         $sFirstToken = '';
         if ($iDepth < Phrase::MAX_DEPTH) {
-            while (count($aWords) > 1) {
+            while (count($aWords) > 1 && count($aResult) < Phrase::MAX_SETS) {
                 $sWord = array_pop($aWords);
                 $sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
                 $aRest = $this->createInverseWordSets($aWords, $iDepth + 1);

--- a/test/php/Nominatim/PhraseTest.php
+++ b/test/php/Nominatim/PhraseTest.php
@@ -6,7 +6,12 @@ require_once(CONST_BasePath.'/lib/Phrase.php');
 
 class PhraseTest extends \PHPUnit\Framework\TestCase
 {
-
+    # Geocode.php calls the SQL function make_standard_name, which does
+    # normalising and trimming.
+    private function makeStandardName($sPhrase)
+    {
+        return preg_replace('/  +/', ' ', trim($sPhrase));
+    }
 
     private function serializeSets($aSets)
     {
@@ -48,6 +53,14 @@ class PhraseTest extends \PHPUnit\Framework\TestCase
             $this->serializeSets($oPhrase->getWordSets())
         );
 
+        # trailing and multiple spaces are removed
+        $oPhrase = new Phrase($this->makeStandardName('  a     b  '), '');
+        $this->assertEquals(
+            '(a b),(a|b)',
+            $this->serializeSets($oPhrase->getWordSets())
+        );
+
+
         $oPhrase = new Phrase('a b c', '');
         $this->assertEquals(
             '(a b c),(a|b c),(a|b|c),(a b|c)',
@@ -74,6 +87,15 @@ class PhraseTest extends \PHPUnit\Framework\TestCase
     }
 
 
+    public function testUnique()
+    {
+        $oPhrase = new Phrase('1 2 3 4 5 6 7 8 9 10', '');
+        # serialize, then split again to get a one-dimensional array
+        $aWordsets = explode(',', $this->serializeSets($oPhrase->getWordSets()));
+        $this->assertEquals(count($aWordsets), count(array_unique($aWordsets)));
+    }
+
+
     public function testMaxDepth()
     {
         $oPhrase = new Phrase(join(' ', array_fill(0, 4, 'a')), '');
@@ -85,5 +107,15 @@ class PhraseTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(41226, count($oPhrase->getWordSets()));
         $oPhrase->invertWordSets();
         $this->assertEquals(41226, count($oPhrase->getWordSets()));
+    }
+
+
+    public function testMaxSets()
+    {
+        // usually 100 words (even 20) would max out memory
+        $oPhrase = new Phrase(join(' ', array_fill(0, 100, 'a')), '');
+        $this->assertLessThan(Phrase::MAX_SETS * 1.1, count($oPhrase->getWordSets()));
+        $oPhrase->invertWordSets();
+        $this->assertLessThan(Phrase::MAX_SETS * 1.1, count($oPhrase->getWordSets()));
     }
 }


### PR DESCRIPTION
Queries containing many words can exhaust the process memory which causes HTTP 500 responses. 

`
[Wed Oct 31 17:10:25.516006 2018] [php7:error] [pid 3320] [client ::1:34704] PHP Fatal error:  Allowed memory size of 209715200 bytes exhausted (tried to allocate 20480 bytes) in /home/vagrant/Nominatim/lib/Phrase.php on line 103
`

I found that to be the case after about 18 words, though of course it would also be depended on how long each word is. 

Test query, which is likely not even an address `中国人民大学 (2016年) 文学院 清华大学 (2008年) 新闻与传播学院` which gets normalized by `make_standard_word` to `herezhong guo ren min da xu 2016 nian wen xu yuan qing hua da xu 2008 nian xin wen yu chuan bo xu yuan` (24 words). Here memory is exhausted between 100.000 and 150.000 word sets.

It might be worth considering putting that into configuration for those installations that give PHP processes a higher memory limit. Or instead adjusting the MAX_DEPTH by number of initial words.