### PR TITLE
match languages such as ja_rm (or any other with underscore) properly

### DIFF
--- a/lib/ParameterParser.php
+++ b/lib/ParameterParser.php
@@ -91,7 +91,7 @@ class ParameterParser
         $sLangString = $this->getString('accept-language', $sFallback);
 
         if ($sLangString) {
-            if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER)) {
+            if (preg_match_all('/(([a-z]{1,8})([-_][a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER)) {
                 foreach ($aLanguagesParse as $iLang => $aLanguage) {
                     $aLanguages[$aLanguage[1]] = isset($aLanguage[5])?(float)$aLanguage[5]:1 - ($iLang/100);
                     if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = $aLanguages[$aLanguage[1]]/10;

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -223,5 +223,27 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
                            'ref' => 'ref',
                            'type' => 'type',
                           ), $oParams->getPreferredLanguages('default'));
+
+        $oParams = new ParameterParser(array('accept-language' => 'ja_rm,zh_pinyin'));
+        $this->assertSame(array(
+                           'short_name:ja_rm' => 'short_name:ja_rm',
+                           'name:ja_rm' => 'name:ja_rm',
+                           'short_name:zh_pinyin' => 'short_name:zh_pinyin',
+                           'name:zh_pinyin' => 'name:zh_pinyin',
+                           'short_name:ja' => 'short_name:ja',
+                           'name:ja' => 'name:ja',
+                           'short_name:zh' => 'short_name:zh',
+                           'name:zh' => 'name:zh',
+                           'short_name' => 'short_name',
+                           'name' => 'name',
+                           'brand' => 'brand',
+                           'official_name:ja_rm' => 'official_name:ja_rm',
+                           'official_name:zh_pinyin' => 'official_name:zh_pinyin',
+                           'official_name:ja' => 'official_name:ja',
+                           'official_name:zh' => 'official_name:zh',
+                           'official_name' => 'official_name',
+                           'ref' => 'ref',
+                           'type' => 'type',
+                          ), $oParams->getPreferredLanguages('default'));
     }
 }


### PR DESCRIPTION
ja_rm does nothing:
https://nominatim.openstreetmap.org/reverse.php?format=jsonv2&lat=35.6828387&lon=139.7594549&zoom=12&namedetails=1&accept-language=ja_rm

ko-Latn works as expected, for example
https://nominatim.openstreetmap.org/reverse.php?format=jsonv2&lat=35.1799528&lon=129.0752365&zoom=8&namedetails=1&accept-language=ko-Latn