### PR TITLE
Simplify parsing of postgres and postgis versions

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -30,14 +30,14 @@ function getArraySQL($a)
 
 function getPostgresVersion(&$oDB)
 {
-    $sVersionString = $oDB->getOne('select version()');
-    preg_match('#PostgreSQL ([0-9]+)[.]([0-9]+)[^0-9]#', $sVersionString, $aMatches);
+    $sVersionString = $oDB->getOne('SHOW server_version_num');
+    preg_match('#([0-9]?[0-9])([0-9][0-9])[0-9][0-9]#', $sVersionString, $aMatches);
     return (float) ($aMatches[1].'.'.$aMatches[2]);
 }
 
 function getPostgisVersion(&$oDB)
 {
-    $sVersionString = $oDB->getOne('select postgis_full_version()');
-    preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)( r([0-9]+))?"#', $sVersionString, $aMatches);
+    $sVersionString = $oDB->getOne('select postgis_lib_version()');
+    preg_match('#^([0-9]+)[.]([0-9]+)[.]#', $sVersionString, $aMatches);
     return (float) ($aMatches[1].'.'.$aMatches[2]);
 }

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -102,7 +102,7 @@ class SetupFunctions
         $fPostgresVersion = getPostgresVersion($this->oDB);
         echo 'Postgres version found: '.$fPostgresVersion."\n";
 
-        if ($fPostgresVersion < 9.1) {
+        if ($fPostgresVersion < 9.01) {
             fail('Minimum supported version of Postgresql is 9.1.');
         }
 


### PR DESCRIPTION
Switch to functions server_version_num and postgis_lib_version
which both only return the version string, so that no elaborate
string parsing is necessary anymore. The version string could
become especially cumbersome in pre-release versions.