### PR TITLE
Add a reverse-only mode

### DIFF
--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -98,6 +98,15 @@ you also need to enable these key phrases like this:
 
 Note that this command downloads the phrases from the wiki link above.
 
+### Reverse-only Imports
+
+If you only want to use the Nominatim database for reverse lookups or
+if you plan to use the installation only for exports to a
+[photon](http://photon.komoot.de/) database, then you can set up a database
+without search indexes. Add `--reverse-only` to your setup command above.
+
+This saves about 5% of disk space.
+
 
 ## Installing Tiger housenumber data for the US
 

--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -3,10 +3,6 @@
 
 CREATE INDEX idx_word_word_id on word USING BTREE (word_id) {ts:search-index};
 
-CREATE INDEX idx_search_name_nameaddress_vector ON search_name USING GIN (nameaddress_vector) WITH (fastupdate = off) {ts:search-index};
-CREATE INDEX idx_search_name_name_vector ON search_name USING GIN (name_vector) WITH (fastupdate = off) {ts:search-index};
-CREATE INDEX idx_search_name_centroid ON search_name USING GIST (centroid) {ts:search-index};
-
 CREATE INDEX idx_place_addressline_address_place_id on place_addressline USING BTREE (address_place_id) {ts:search-index};
 
 DROP INDEX IF EXISTS idx_placex_rank_search;

--- a/sql/indices_search.src.sql
+++ b/sql/indices_search.src.sql
@@ -1,0 +1,6 @@
+-- Indices used for /search API.
+-- These indices are created only after the indexing process is done.
+
+CREATE INDEX idx_search_name_nameaddress_vector ON search_name USING GIN (nameaddress_vector) WITH (fastupdate = off) {ts:search-index};
+CREATE INDEX idx_search_name_name_vector ON search_name USING GIN (name_vector) WITH (fastupdate = off) {ts:search-index};
+CREATE INDEX idx_search_name_centroid ON search_name USING GIST (centroid) {ts:search-index};

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -142,17 +142,11 @@ LANGUAGE plpgsql;
 
 
 create or replace function insertSearchName(
-  in_partition INTEGER, in_place_id BIGINT, in_country_code VARCHAR(2), 
-  in_name_vector INTEGER[], in_nameaddress_vector INTEGER[],
-  in_rank_search INTEGER, in_rank_address INTEGER, in_importance FLOAT,
-  in_centroid GEOMETRY, in_geometry GEOMETRY) RETURNS BOOLEAN AS $$
+  in_partition INTEGER, in_place_id BIGINT, in_name_vector INTEGER[],
+  in_rank_search INTEGER, in_rank_address INTEGER, in_geometry GEOMETRY)
+RETURNS BOOLEAN AS $$
 DECLARE
 BEGIN
-
-  DELETE FROM search_name WHERE place_id = in_place_id;
-  INSERT INTO search_name (place_id, search_rank, address_rank, importance, country_code, name_vector, nameaddress_vector, centroid)
-    values (in_place_id, in_rank_search, in_rank_address, in_importance, in_country_code, in_name_vector, in_nameaddress_vector, in_centroid);
-
 -- start
   IF in_partition = -partition- THEN
     DELETE FROM search_name_-partition- values WHERE place_id = in_place_id;
@@ -173,9 +167,6 @@ LANGUAGE plpgsql;
 create or replace function deleteSearchName(in_partition INTEGER, in_place_id BIGINT) RETURNS BOOLEAN AS $$
 DECLARE
 BEGIN
-
-  DELETE from search_name WHERE place_id = in_place_id;
-
 -- start
   IF in_partition = -partition- THEN
     DELETE from search_name_-partition- WHERE place_id = in_place_id;

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -29,6 +29,7 @@ $aCMDOptions
    array('setup-db', '', 0, 1, 0, 0, 'bool', 'Build a blank nominatim db'),
    array('import-data', '', 0, 1, 0, 0, 'bool', 'Import a osm file'),
    array('osm2pgsql-cache', '', 0, 1, 1, 1, 'int', 'Cache size used by osm2pgsql'),
+   array('reverse-only', '', 0, 1, 0, 0, 'bool', 'Do not create search tables and indexes'),
    array('create-functions', '', 0, 1, 0, 0, 'bool', 'Create functions'),
    array('enable-diff-updates', '', 0, 1, 0, 0, 'bool', 'Turn on the code required to make diff updates work'),
    array('enable-debug-statements', '', 0, 1, 0, 0, 'bool', 'Include debug warning statements in pgsql commands'),
@@ -104,7 +105,7 @@ if ($aCMDResult['create-functions'] || $aCMDResult['all']) {
 
 if ($aCMDResult['create-tables'] || $aCMDResult['all']) {
     $bDidSomething = true;
-    $oSetup->createTables();
+    $oSetup->createTables($aCMDResult['reverse-only']);
     $oSetup->createFunctions();
 }
 


### PR DESCRIPTION
Sets up the database without the `search_name` table. Useful when only doing reverse queries or when using Nominatim just as a backend for photon.

Fixes #939.