### PR TITLE
settings.php: when printing error, also exit with error code

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -1,4 +1,4 @@
 <?php
 
 echo "ERROR: Scripts must be run from build directory.\n";
-exit;
+exit(1);


### PR DESCRIPTION
When running the BDD test suite with `BUILDDIR=$HOME/Nominatim` instead of ... well ... the build directory tests fail with database related errors (tables not created) instead of pointing to the real issue (wrong script executed).