### PR TITLE
setup: add hint warnings during wikipedia imports are (sadly) expected

### DIFF
--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -332,12 +332,14 @@ class SetupFunctions
         $sWikiRedirectsFile = CONST_Wikipedia_Data_Path.'/wikipedia_redirect.sql.bin';
         if (file_exists($sWikiArticlesFile)) {
             info('Importing wikipedia articles');
+            echo "You can ignore public.idx_osm_id and pagelinks_pkey related errors below.\n";
             $this->pgsqlRunDropAndRestore($sWikiArticlesFile);
         } else {
             warn('wikipedia article dump file not found - places will have default importance');
         }
         if (file_exists($sWikiRedirectsFile)) {
             info('Importing wikipedia redirects');
+            echo "You can ignore public.idx_wikipedia_redirect_from_title related errors below.\n";
             $this->pgsqlRunDropAndRestore($sWikiRedirectsFile);
         } else {
             warn('wikipedia redirect dump file not found - some place importance values may be missing');
@@ -719,7 +721,7 @@ class SetupFunctions
 
     private function pgsqlRunDropAndRestore($sDumpFile)
     {
-        $sCMD = 'pg_restore -p '.$this->aDSNInfo['port'].' -d '.$this->aDSNInfo['database'].' -Fc --clean '.$sDumpFile;
+        $sCMD = 'pg_restore -p '.$this->aDSNInfo['port'].' -d '.$this->aDSNInfo['database'].' -Fc --clean --no-owner '.$sDumpFile;
         if (isset($this->aDSNInfo['hostspec'])) {
             $sCMD .= ' -h '.$this->aDSNInfo['hostspec'];
         }


### PR DESCRIPTION
Try to have less warnings during wikipedia file import, or at least note they are expected. Related to https://github.com/openstreetmap/Nominatim/issues/1163#issuecomment-439686062

One can check the SQL using `pg_restore file.bin | more` but I don't see an obvious SQL statement causing the warnings.

For reference the current output
```
2018-11-26 13:52:41 == Importing wikipedia articles
pg_restore: [archiver (db)] Error while PROCESSING TOC:
pg_restore: [archiver (db)] Error from TOC entry 2787; 1259 2164299 INDEX idx_osm_id brian
pg_restore: [archiver (db)] could not execute query: ERROR:  index "idx_osm_id" does not exist
    Command was: DROP INDEX public.idx_osm_id;

pg_restore: [archiver (db)] Error from TOC entry 2789; 2606 2164220 CONSTRAINT pagelinks_pkey brian
pg_restore: [archiver (db)] could not execute query: ERROR:  constraint "pagelinks_pkey" of relation "wikipedia_article" does not exist
    Command was: ALTER TABLE ONLY public.wikipedia_article DROP CONSTRAINT pagelinks_pkey;

WARNING: errors ignored on restore: 2
2018-11-26 14:12:51 == Importing wikipedia redirects
pg_restore: [archiver (db)] Error while PROCESSING TOC:
pg_restore: [archiver (db)] Error from TOC entry 2783; 1259 2164961 INDEX idx_wikipedia_redirect_from_title brian
pg_restore: [archiver (db)] could not execute query: ERROR:  index "idx_wikipedia_redirect_from_title" does not exist
    Command was: DROP INDEX public.idx_wikipedia_redirect_from_title;

WARNING: errors ignored on restore: 1
Summary of warnings:

  * resetting threads to 1
```