### PR TITLE
Remove self from place addressline

### DIFF
--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -133,7 +133,7 @@ style     | Import time  |  DB size   |  after drop
 admin     |    5h        |  190 GB    |   20 GB
 street    |   42h        |  400 GB    |  180 GB
 address   |   59h        |  500 GB    |  260 GB
-full      |   80h        |  590 GB    |  320 GB
+full      |   80h        |  575 GB    |  300 GB
 
 You can also customize the styles further. For an description of the
 style format see [the developement section](../develop/Import.md).

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -1311,10 +1311,6 @@ BEGIN
       --DEBUG: RAISE WARNING 'Waterway processed';
   END IF;
 
-  -- Adding ourselves to the list simplifies address calculations later
-  INSERT INTO place_addressline (place_id, address_place_id, fromarea, isaddress, distance, cached_rank_address)
-    VALUES (NEW.place_id, NEW.place_id, true, true, 0, NEW.rank_address); 
-
   -- What level are we searching from
   search_maxrank := NEW.rank_search;
 
@@ -2305,6 +2301,9 @@ create type addressline as (
   distance FLOAT
 );
 
+-- Compute the list of address parts for the given place.
+--
+-- If in_housenumber is greator or equal 0, look for an interpolation.
 CREATE OR REPLACE FUNCTION get_addressdata(in_place_id BIGINT, in_housenumber INTEGER) RETURNS setof addressline 
   AS $$
 DECLARE
@@ -2322,50 +2321,66 @@ DECLARE
   searchclass TEXT;
   searchtype TEXT;
   countryname HSTORE;
-  hadcountry BOOLEAN;
 BEGIN
+  -- The place ein question might not have a direct entry in place_addressline.
+  -- Look for the parent of such places then and save if in for_place_id.
+
   -- first query osmline (interpolation lines)
-  select parent_place_id, country_code, 30, postcode, null, 'place', 'house' from location_property_osmline 
-    WHERE place_id = in_place_id AND in_housenumber>=startnumber AND in_housenumber <= endnumber
-    INTO for_place_id,searchcountrycode, searchrankaddress, searchpostcode, searchhousename, searchclass, searchtype;
-  IF for_place_id IS NOT NULL THEN
-    searchhousenumber = in_housenumber::text;
+  IF in_housenumber >= 0 THEN
+    SELECT parent_place_id, country_code, in_housenumber::text, 30, postcode,
+           null, 'place', 'house'
+      FROM location_property_osmline
+      WHERE place_id = in_place_id AND in_housenumber>=startnumber
+            AND in_housenumber <= endnumber
+      INTO for_place_id, searchcountrycode, searchhousenumber, searchrankaddress,
+           searchpostcode, searchhousename, searchclass, searchtype;
   END IF;
 
   --then query tiger data
   -- %NOTIGERDATA% IF 0 THEN
-  IF for_place_id IS NULL THEN
-    select parent_place_id,'us', 30, postcode, null, 'place', 'house' from location_property_tiger 
-      WHERE place_id = in_place_id AND in_housenumber>=startnumber AND in_housenumber <= endnumber
-      INTO for_place_id,searchcountrycode, searchrankaddress, searchpostcode, searchhousename, searchclass, searchtype;
-    IF for_place_id IS NOT NULL THEN
-      searchhousenumber = in_housenumber::text;
-    END IF;
+  IF for_place_id IS NULL AND in_housenumber >= 0 THEN
+    SELECT parent_place_id, 'us', in_housenumber::text, 30, postcode, null,
+           'place', 'house'
+      FROM location_property_tiger
+      WHERE place_id = in_place_id AND in_housenumber >= startnumber
+            AND in_housenumber <= endnumber
+      INTO for_place_id, searchcountrycode, searchhousenumber, searchrankaddress,
+           searchpostcode, searchhousename, searchclass, searchtype;
   END IF;
   -- %NOTIGERDATA% END IF;
 
   -- %NOAUXDATA% IF 0 THEN
   IF for_place_id IS NULL THEN
-    select parent_place_id,'us', housenumber, 30, postcode, null, 'place', 'house' from location_property_aux
+    SELECT parent_place_id, 'us', housenumber, 30, postcode, null, 'place', 'house'
+      FROM location_property_aux
       WHERE place_id = in_place_id
-      INTO for_place_id,searchcountrycode, searchhousenumber, searchrankaddress, searchpostcode, searchhousename, searchclass, searchtype;
+      INTO for_place_id,searchcountrycode, searchhousenumber, searchrankaddress,
+           searchpostcode, searchhousename, searchclass, searchtype;
   END IF;
   -- %NOAUXDATA% END IF;
 
   -- postcode table
   IF for_place_id IS NULL THEN
-    select parent_place_id, country_code, rank_address, postcode, 'place', 'postcode'
+    SELECT parent_place_id, country_code, rank_address, postcode, 'place', 'postcode'
       FROM location_postcode
       WHERE place_id = in_place_id
-      INTO for_place_id, searchcountrycode, searchrankaddress, searchpostcode, searchclass, searchtype;
+      INTO for_place_id, searchcountrycode, searchrankaddress, searchpostcode,
+           searchclass, searchtype;
   END IF;
 
+  -- POI objects in the placex table
   IF for_place_id IS NULL THEN
-    select parent_place_id, country_code, housenumber, rank_search, postcode, name, class, type from placex 
-      WHERE place_id = in_place_id and  rank_search > 27
-      INTO for_place_id, searchcountrycode, searchhousenumber, searchrankaddress, searchpostcode, searchhousename, searchclass, searchtype;
+    SELECT parent_place_id, country_code, housenumber, rank_search, postcode,
+           name, class, type
+      FROM placex
+      WHERE place_id = in_place_id and rank_search > 27
+      INTO for_place_id, searchcountrycode, searchhousenumber, searchrankaddress,
+           searchpostcode, searchhousename, searchclass, searchtype;
   END IF;
 
+  -- If for_place_id is still NULL at this point then the object has its own
+  -- entry in place_address line. However, still check if there is not linked
+  -- place we should be using instead.
   IF for_place_id IS NULL THEN
     select coalesce(linked_place_id, place_id),  country_code,
            housenumber, rank_search, postcode, null
@@ -2375,15 +2390,51 @@ BEGIN
 
 --RAISE WARNING '% % % %',searchcountrycode, searchhousenumber, searchrankaddress, searchpostcode;
 
-  found := 1000;
-  hadcountry := false;
-  FOR location IN 
-    select placex.place_id, osm_type, osm_id, name,
-      class, type, admin_level, true as isaddress,
-      CASE WHEN rank_address = 0 THEN 100 WHEN rank_address = 11 THEN 5 ELSE rank_address END as rank_address,
-      0 as distance, country_code, postcode
-      from placex
-      where place_id = for_place_id 
+  found := 1000; -- the lowest rank_address included
+
+  -- Return the record for the base entry.
+  FOR location IN
+    SELECT placex.place_id, osm_type, osm_id, name,
+           class, type, admin_level,
+           type not in ('postcode', 'postal_code') as isaddress,
+           CASE WHEN rank_address = 0 THEN 100
+                WHEN rank_address = 11 THEN 5
+                ELSE rank_address END as rank_address,
+           0 as distance, country_code, postcode
+      FROM placex
+      WHERE place_id = for_place_id
+  LOOP
+--RAISE WARNING '%',location;
+    IF searchcountrycode IS NULL AND location.country_code IS NOT NULL THEN
+      searchcountrycode := location.country_code;
+    END IF;
+    IF location.rank_address < 4 THEN
+      -- no country locations for ranks higher than country
+      searchcountrycode := NULL;
+    END IF;
+    countrylocation := ROW(location.place_id, location.osm_type, location.osm_id,
+                           location.name, location.class, location.type,
+                           location.admin_level, true, location.isaddress,
+                           location.rank_address, location.distance)::addressline;
+    RETURN NEXT countrylocation;
+    found := location.rank_address;
+  END LOOP;
+
+  FOR location IN
+    SELECT placex.place_id, osm_type, osm_id, name,
+           CASE WHEN extratags ? 'place' THEN 'place' ELSE class END as class,
+           CASE WHEN extratags ? 'place' THEN extratags->'place' ELSE type END as type,
+           admin_level, fromarea, isaddress,
+           CASE WHEN rank_address = 11 THEN 5 ELSE rank_address END as rank_address,
+           distance, country_code, postcode
+      FROM place_addressline join placex on (address_place_id = placex.place_id)
+      WHERE place_addressline.place_id = for_place_id
+            AND (cached_rank_address >= 4 AND cached_rank_address < searchrankaddress)
+            AND linked_place_id is null
+            AND (placex.country_code IS NULL OR searchcountrycode IS NULL
+                 OR placex.country_code = searchcountrycode)
+      ORDER BY rank_address desc, isaddress desc, fromarea desc,
+               distance asc, rank_search desc
   LOOP
 --RAISE WARNING '%',location;
     IF searchcountrycode IS NULL AND location.country_code IS NOT NULL THEN
@@ -2391,87 +2442,50 @@ BEGIN
     END IF;
     IF location.type in ('postcode', 'postal_code') THEN
       location.isaddress := FALSE;
-    ELSEIF location.rank_address = 4 THEN
-      hadcountry := true;
     END IF;
-    IF location.rank_address < 4 AND NOT hadcountry THEN
-      select name from country_name where country_code = searchcountrycode limit 1 INTO countryname;
-      IF countryname IS NOT NULL THEN
-        countrylocation := ROW(null, null, null, countryname, 'place', 'country', null, true, true, 4, 0)::addressline;
-        RETURN NEXT countrylocation;
-      END IF;
-    END IF;
-    countrylocation := ROW(location.place_id, location.osm_type, location.osm_id, location.name, location.class, 
-                           location.type, location.admin_level, true, location.isaddress, location.rank_address,
+    countrylocation := ROW(location.place_id, location.osm_type, location.osm_id,
+                           location.name, location.class, location.type,
+                           location.admin_level, location.fromarea,
+                           location.isaddress, location.rank_address,
                            location.distance)::addressline;
     RETURN NEXT countrylocation;
     found := location.rank_address;
   END LOOP;
 
-  FOR location IN 
-    select placex.place_id, osm_type, osm_id, name,
-      CASE WHEN extratags ? 'place' THEN 'place' ELSE class END as class,
-      CASE WHEN extratags ? 'place' THEN extratags->'place' ELSE type END as type,
-      admin_level, fromarea, isaddress,
-      CASE WHEN address_place_id = for_place_id AND rank_address = 0 THEN 100 WHEN rank_address = 11 THEN 5 ELSE rank_address END as rank_address,
-      distance,country_code,postcode
-      from place_addressline join placex on (address_place_id = placex.place_id) 
-      where place_addressline.place_id = for_place_id 
-      and (cached_rank_address > 0 AND cached_rank_address < searchrankaddress)
-      and address_place_id != for_place_id and linked_place_id is null
-      and (placex.country_code IS NULL OR searchcountrycode IS NULL OR placex.country_code = searchcountrycode)
-      order by rank_address desc,isaddress desc,fromarea desc,distance asc,rank_search desc
-  LOOP
---RAISE WARNING '%',location;
-    IF searchcountrycode IS NULL AND location.country_code IS NOT NULL THEN
-      searchcountrycode := location.country_code;
-    END IF;
-    IF location.type in ('postcode', 'postal_code') THEN
-      location.isaddress := FALSE;
-    END IF;
-    IF location.rank_address = 4 AND location.isaddress THEN
-      hadcountry := true;
-    END IF;
-    IF location.rank_address < 4 AND NOT hadcountry THEN
-      select name from country_name where country_code = searchcountrycode limit 1 INTO countryname;
-      IF countryname IS NOT NULL THEN
-        countrylocation := ROW(null, null, null, countryname, 'place', 'country', null, true, true, 4, 0)::addressline;
-        RETURN NEXT countrylocation;
-      END IF;
-    END IF;
-    countrylocation := ROW(location.place_id, location.osm_type, location.osm_id, location.name, location.class, 
-                           location.type, location.admin_level, location.fromarea, location.isaddress, location.rank_address, 
-                           location.distance)::addressline;
-    RETURN NEXT countrylocation;
-    found := location.rank_address;
-  END LOOP;
-
+  -- If no country was included yet, add the name information from country_name.
   IF found > 4 THEN
-    select name from country_name where country_code = searchcountrycode limit 1 INTO countryname;
+    SELECT name FROM country_name
+      WHERE country_code = searchcountrycode LIMIT 1 INTO countryname;
 --RAISE WARNING '% % %',found,searchcountrycode,countryname;
     IF countryname IS NOT NULL THEN
-      location := ROW(null, null, null, countryname, 'place', 'country', null, true, true, 4, 0)::addressline;
+      location := ROW(null, null, null, countryname, 'place', 'country',
+                      null, true, true, 4, 0)::addressline;
       RETURN NEXT location;
     END IF;
   END IF;
 
+  -- Finally add some artificial rows.
   IF searchcountrycode IS NOT NULL THEN
-    location := ROW(null, null, null, hstore('ref', searchcountrycode), 'place', 'country_code', null, true, false, 4, 0)::addressline;
+    location := ROW(null, null, null, hstore('ref', searchcountrycode),
+                    'place', 'country_code', null, true, false, 4, 0)::addressline;
     RETURN NEXT location;
   END IF;
 
   IF searchhousename IS NOT NULL THEN
-    location := ROW(in_place_id, null, null, searchhousename, searchclass, searchtype, null, true, true, 29, 0)::addressline;
+    location := ROW(in_place_id, null, null, searchhousename, searchclass,
+                    searchtype, null, true, true, 29, 0)::addressline;
     RETURN NEXT location;
   END IF;
 
   IF searchhousenumber IS NOT NULL THEN
-    location := ROW(in_place_id, null, null, hstore('ref', searchhousenumber), 'place', 'house_number', null, true, true, 28, 0)::addressline;
+    location := ROW(in_place_id, null, null, hstore('ref', searchhousenumber),
+                    'place', 'house_number', null, true, true, 28, 0)::addressline;
     RETURN NEXT location;
   END IF;
 
   IF searchpostcode IS NOT NULL THEN
-    location := ROW(null, null, null, hstore('ref', searchpostcode), 'place', 'postcode', null, true, true, 5, 0)::addressline;
+    location := ROW(null, null, null, hstore('ref', searchpostcode), 'place',
+                    'postcode', null, true, true, 5, 0)::addressline;
     RETURN NEXT location;
   END IF;
 


### PR DESCRIPTION
Wasn't really needed anymore, as the own place is always looked up.

After applying the change, the self-references can be safely removed with:

```
DELETE FROM place_addressline WHERE place_id = address_place_id;
```
Saves 15-20 GB on a planet import.