### PR TITLE
BDD: support for DB_PORT environment variable

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -66,7 +66,7 @@ To run the functional tests, do
     cd test/bdd
     behave
 
-The tests can be configured with a set of environment variables:
+The tests can be configured with a set of environment variables (`behave -D key=val`):
 
  * `BUILDDIR` - build directory of Nominatim installation to test
  * `TEMPLATE_DB` - name of template database used as a skeleton for
@@ -74,6 +74,7 @@ The tests can be configured with a set of environment variables:
  * `TEST_DB` - name of test database (db tests)
  * `API_TEST_DB` - name of the database containing the API test data (api tests)
  * `DB_HOST` - (optional) hostname of database host
+ * `DB_PORT` - (optional) port of database on host
  * `DB_USER` - (optional) username of database login
  * `DB_PASS` - (optional) password for database login
  * `SERVER_MODULE_PATH` - (optional) path on the Postgres server to Nominatim

--- a/test/bdd/environment.py
+++ b/test/bdd/environment.py
@@ -15,6 +15,7 @@ userconfig = {
     'REMOVE_TEMPLATE' : False,
     'KEEP_TEST_DB' : False,
     'DB_HOST' : None,
+    'DB_PORT' : None,
     'DB_USER' : None,
     'DB_PASS' : None,
     'TEMPLATE_DB' : 'test_template_nominatim',
@@ -35,6 +36,7 @@ class NominatimEnvironment(object):
         self.build_dir = os.path.abspath(config['BUILDDIR'])
         self.src_dir = os.path.abspath(os.path.join(os.path.split(__file__)[0], "../.."))
         self.db_host = config['DB_HOST']
+        self.db_port = config['DB_PORT']
         self.db_user = config['DB_USER']
         self.db_pass = config['DB_PASS']
         self.template_db = config['TEMPLATE_DB']
@@ -54,6 +56,8 @@ class NominatimEnvironment(object):
         dbargs = {'database': dbname}
         if self.db_host:
             dbargs['host'] = self.db_host
+        if self.db_port:
+            dbargs['port'] = self.db_port
         if self.db_user:
             dbargs['user'] = self.db_user
         if self.db_pass:
@@ -69,10 +73,11 @@ class NominatimEnvironment(object):
 
     def write_nominatim_config(self, dbname):
         f = open(self.local_settings_file, 'w')
-        f.write("<?php\n  @define('CONST_Database_DSN', 'pgsql://%s:%s@%s/%s');\n" %
+        f.write("<?php\n  @define('CONST_Database_DSN', 'pgsql://%s:%s@%s%s/%s');\n" %
                 (self.db_user if self.db_user else '',
                  self.db_pass if self.db_pass else '',
                  self.db_host if self.db_host else '',
+                 (':' + self.db_port) if self.db_port else '',
                  dbname))
         f.write("@define('CONST_Osm2pgsql_Flatnode_File', null);\n")
         f.close()


### PR DESCRIPTION
Setting `behave -D DB_HOST=localhost:1234` also works, but a separate variable is cleaner. I have my (11GB) test db on a remote host and use ssh tunnel so the remote host doesn't have to listen on a port.