### PR TITLE
README: tiny markdown syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The source code is available under a GPLv2 license.
 Contributing
 ============
 
-Contributions are welcome. For details see [CONTRIBUTING.md](contribution guide).
+Contributions are welcome. For details see [contribution guide](CONTRIBUTING.md).
 
 Both bug reports and pull requests are welcome.
 


### PR DESCRIPTION
Fixed one link that didn't get rendered.

![image](https://user-images.githubusercontent.com/3727288/51858505-2dca9200-2335-11e9-976d-99c562d2038d.png)


