### PR TITLE
Allow to hand over additional Osm2pgsql command line arguments

### DIFF
--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -189,6 +189,7 @@ class SetupFunctions
             fail("osm2pgsql not found in '$osm2pgsql'");
         }
 
+        $osm2pgsql .= ' '.CONST_Osm2pgsql_Additional_Cmd_Args;
         $osm2pgsql .= ' -S '.CONST_Import_Style;
 
         if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {

--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -63,6 +63,8 @@ if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 // osm2pgsql output tables (aka main table) - update only
 @define('CONST_Tablespace_Place_Data', false);
 @define('CONST_Tablespace_Place_Index', false);
+// osm2pgsql additional commandline arguments
+@define('CONST_Osm2pgsql_Additional_Cmd_Args', '');
 // address computation tables - update only
 @define('CONST_Tablespace_Address_Data', false);
 @define('CONST_Tablespace_Address_Index', false);


### PR DESCRIPTION
This enables users to add whatever command line argument for the invocation of Osm2pgsql they want, e.g. `--extra-attributes`.