### PR TITLE
Travis-ci: upgrade to xenial (Ubuntu-16)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/test/php/phpunit.xml
+++ b/test/php/phpunit.xml
@@ -7,7 +7,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="true"
     bootstrap="./bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"
     >

--- a/vagrant/db_php_patch.txt
+++ b/vagrant/db_php_patch.txt
@@ -1,0 +1,10 @@
+--- DB.php 2015-11-24 15:09:14.000000000 +0100
++++ DB_new.php 2019-02-07 17:02:25.000000000 +0100
+@@ -772,7 +772,7 @@
+             $parsed['dbsyntax'] = $str;
+         }
+
+-        if (!count($dsn)) {
++        if (!$dsn || !count($dsn)) {
+             return $parsed;
+         }


### PR DESCRIPTION
Replaces all PEAR install lines as http://pear.php.net/ is still down (4 weeks now? https://twitter.com/pear).

`phpunit.xml` needed a tiny change as that parameter is no longer supported by PHPCS 7.

Added patch file for https://github.com/openstreetmap/Nominatim/issues/1184

Many tests are failing but I haven't figured out yet if that's related to any changes in this PR or unrelated. There doesn't seem to be a pattern.
```
Failing scenarios:
  db/import/interpolation.feature:210  addr:street on interpolation way
  db/import/interpolation.feature:252  addr:street on housenumber way
  db/import/linking.feature:17  Waterways are linked when in waterway relations
  db/import/linking.feature:72  Waterways are not linked when the way type is not a river feature
  db/import/linking.feature:92  Side streams are linked only when they have the same name
  db/import/parenting.feature:5  Address inherits postcode from its street unless it has a postcode
  db/query/normalization.feature:6  Case-insensitivity of search
  db/query/normalization.feature:31  Multiple spaces in name
  db/query/normalization.feature:53  Special characters in name
  db/query/normalization.feature:115  Landuse with name are found
  db/query/normalization.feature:130  Postcode boundaries without ref
  db/query/normalization.feature:140  Unprintable characters in postcodes are ignored
  db/query/search_simple.feature:5  Search for place node
  db/query/search_simple.feature:15  Updating postcode in postcode boundaries without ref
  db/update/linked_places.feature:5  Add linked place when linking relation is renamed
  db/update/linked_places.feature:28  Add linked place when linking relation is removed
  db/update/linked_places.feature:49  Remove linked place when linking relation is added
  db/update/linked_places.feature:69  Remove linked place when linking relation is renamed
  db/update/naming.feature:5  Delete postcode from postcode boundaries without ref
```