### PR TITLE
remove phpunit config key deprecated since version 3.5

### DIFF
--- a/test/php/phpunit.xml
+++ b/test/php/phpunit.xml
@@ -7,7 +7,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="true"
     bootstrap="./bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"
     >


### PR DESCRIPTION
This configuration key got removed 2010 (phpunit 3.5) and in newest phpunit (version 7) causes errors.

https://github.com/sebastianbergmann/phpunit/commit/157a73025e15af8294be72c2bbc05a1f569a0879#diff-14530192af0798464cc31333cf945f27