### PR TITLE
replace database abstraction DB with PDO

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -171,7 +171,7 @@ If the Postgres installation is behind a firewall, you can try
 inside the virtual machine. It will map the port to `localhost:9999` and then
 you edit `settings/local.php` with
 
-    @define('CONST_Database_DSN', 'pgsql://postgres@localhost:9999/nominatim_it');
+    @define('CONST_Database_DSN', 'pgsql:host=localhost;port=9999;user=postgres;dbname=nominatim_it');
 
 To access postgres directly remember to specify the hostname, e.g. `psql --host localhost --port 9999 nominatim_it`
 

--- a/docs/admin/Migration.md
+++ b/docs/admin/Migration.md
@@ -9,6 +9,18 @@ SQL statements should be executed from the postgres commandline. Execute
 
 ## 3.2.0 -> master
 
+### New database connection string (DSN) format
+
+Previously database connection setting (`CONST_Database_DSN` in `settings/*.php`) had the format
+
+   * (simple) `pgsql://@/nominatim`
+   * (complex) `pgsql://johndoe:secret@machine1.domain.com:1234/db1`
+
+The new format is
+
+   * (simple) `pgsql:dbname=nominatim`
+   * (complex) `pgsql:dbname=db1;host=machine1.domain.com;port=1234;user=johndoe;password=secret`
+
 ### Natural Earth country boundaries no longer needed as fallback
 
 ```

--- a/lib/DatabaseError.php
+++ b/lib/DatabaseError.php
@@ -5,10 +5,12 @@ namespace Nominatim;
 class DatabaseError extends \Exception
 {
 
-    public function __construct($message, $code = 500, Exception $previous = null, $oSql)
+    public function __construct($message, $code = 500, Exception $previous = null, $oPDOErr, $sSql = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->oSql = $oSql;
+        // https://secure.php.net/manual/en/class.pdoexception.php
+        $this->oPDOErr = $oPDOErr;
+        $this->sSql = $sSql;
     }
 
     public function __toString()
@@ -18,15 +20,15 @@ class DatabaseError extends \Exception
 
     public function getSqlError()
     {
-        return $this->oSql->getMessage();
+        return $this->oPDOErr->getMessage();
     }
 
     public function getSqlDebugDump()
     {
         if (CONST_Debug) {
-            return var_export($this->oSql, true);
+            return var_export($this->oPDOErr, true);
         } else {
-            return $this->oSql->getUserInfo();
+            return $this->sSql;
         }
     }
 }

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -527,8 +527,8 @@ class Geocode
         $sNormQuery = $this->normTerm($this->sQuery);
         Debug::printVar('Normalized query', $sNormQuery);
 
-        $sLanguagePrefArraySQL = getArraySQL(
-            array_map('getDBQuoted', $this->aLangPrefOrder)
+        $sLanguagePrefArraySQL = $this->oDB->getArraySQL(
+            $this->oDB->getDBQuotedList($this->aLangPrefOrder)
         );
 
         $sQuery = $this->sQuery;
@@ -629,7 +629,7 @@ class Geocode
             $aPhrases = array();
             foreach ($aInPhrases as $iPhrase => $sPhrase) {
                 $sPhrase = chksql(
-                    $this->oDB->getOne('SELECT make_standard_name('.getDBQuoted($sPhrase).')'),
+                    $this->oDB->getOne('SELECT make_standard_name('.$this->oDB->getDBQuoted($sPhrase).')'),
                     'Cannot normalize query string (is it a UTF-8 string?)'
                 );
                 if (trim($sPhrase)) {
@@ -647,7 +647,7 @@ class Geocode
             if (!empty($aTokens)) {
                 $sSQL = 'SELECT word_id, word_token, word, class, type, country_code, operator, search_name_count';
                 $sSQL .= ' FROM word ';
-                $sSQL .= ' WHERE word_token in ('.join(',', array_map('getDBQuoted', $aTokens)).')';
+                $sSQL .= ' WHERE word_token in ('.join(',', $this->oDB->getDBQuotedList($aTokens)).')';
 
                 Debug::printSQL($sSQL);
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -52,7 +52,7 @@ class PlaceLookup
     {
         $aLangs = $oParams->getPreferredLanguages();
         $this->aLangPrefOrderSql =
-            'ARRAY['.join(',', array_map('getDBQuoted', $aLangs)).']';
+            'ARRAY['.join(',', $this->oDB->getDBQuotedList($aLangs)).']';
 
         $this->bExtraTags = $oParams->getBool('extratags', false);
         $this->bNameDetails = $oParams->getBool('namedetails', false);
@@ -132,8 +132,9 @@ class PlaceLookup
 
     public function setLanguagePreference($aLangPrefOrder)
     {
-        $this->aLangPrefOrderSql =
-            'ARRAY['.join(',', array_map('getDBQuoted', $aLangPrefOrder)).']';
+        $this->aLangPrefOrderSql = $this->oDB->getArraySQL(
+            $this->oDB->getDBQuotedList($aLangPrefOrder)
+        );
     }
 
     private function addressImportanceSql($sGeometry, $sPlaceId)
@@ -515,7 +516,7 @@ class PlaceLookup
 
             $aPointPolygon = chksql($this->oDB->getRow($sSQL), 'Could not get outline');
 
-            if ($aPointPolygon['place_id']) {
+            if ($aPointPolygon && $aPointPolygon['place_id']) {
                 if ($aPointPolygon['centrelon'] !== null && $aPointPolygon['centrelat'] !== null) {
                     $aOutlineResult['lat'] = $aPointPolygon['centrelat'];
                     $aOutlineResult['lon'] = $aPointPolygon['centrelon'];

--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -504,8 +504,10 @@ class SearchDescription
 
         Debug::printSQL($sSQL);
 
+        $iPlaceId = $oDB->getOne($sSQL);
+
         $aResults = array();
-        foreach (chksql($oDB->getCol($sSQL)) as $iPlaceId) {
+        if ($iPlaceId) {
             $aResults[$iPlaceId] = new Result($iPlaceId);
         }
 
@@ -577,7 +579,7 @@ class SearchDescription
             $sSQL .= ', search_name s ';
             $sSQL .= 'WHERE s.place_id = p.parent_place_id ';
             $sSQL .= 'AND array_cat(s.nameaddress_vector, s.name_vector)';
-            $sSQL .= '      @> '.getArraySQL($this->aAddress).' AND ';
+            $sSQL .= '      @> '.$oDB->getArraySQL($this->aAddress).' AND ';
         } else {
             $sSQL .= 'WHERE ';
         }
@@ -633,14 +635,14 @@ class SearchDescription
         }
 
         if (!empty($this->aName)) {
-            $aTerms[] = 'name_vector @> '.getArraySQL($this->aName);
+            $aTerms[] = 'name_vector @> '.$oDB->getArraySQL($this->aName);
         }
         if (!empty($this->aAddress)) {
             // For infrequent name terms disable index usage for address
             if ($this->bRareName) {
-                $aTerms[] = 'array_cat(nameaddress_vector,ARRAY[]::integer[]) @> '.getArraySQL($this->aAddress);
+                $aTerms[] = 'array_cat(nameaddress_vector,ARRAY[]::integer[]) @> '.$oDB->getArraySQL($this->aAddress);
             } else {
-                $aTerms[] = 'nameaddress_vector @> '.getArraySQL($this->aAddress);
+                $aTerms[] = 'nameaddress_vector @> '.$oDB->getArraySQL($this->aAddress);
             }
         }
 
@@ -695,7 +697,7 @@ class SearchDescription
         if (!empty($this->aFullNameAddress)) {
             $sExactMatchSQL = ' ( ';
             $sExactMatchSQL .= ' SELECT count(*) FROM ( ';
-            $sExactMatchSQL .= '  SELECT unnest('.getArraySQL($this->aFullNameAddress).')';
+            $sExactMatchSQL .= '  SELECT unnest('.$oDB->getArraySQL($this->aFullNameAddress).')';
             $sExactMatchSQL .= '    INTERSECT ';
             $sExactMatchSQL .= '  SELECT unnest(nameaddress_vector)';
             $sExactMatchSQL .= ' ) s';

--- a/lib/Status.php
+++ b/lib/Status.php
@@ -3,7 +3,6 @@
 namespace Nominatim;
 
 use Exception;
-use PEAR;
 
 class Status
 {
@@ -16,12 +15,18 @@ class Status
 
     public function status()
     {
-        if (!$this->oDB || PEAR::isError($this->oDB)) {
+        if (!$this->oDB) {
             throw new Exception('No database', 700);
         }
 
+        try {
+            $this->oDB->connect();
+        } catch (\Nominatim\DatabaseError $e) {
+            throw new Exception('Database connection failed', 700);
+        }
+
         $sStandardWord = $this->oDB->getOne("SELECT make_standard_name('a')");
-        if (PEAR::isError($sStandardWord)) {
+        if ($sStandardWord === false) {
             throw new Exception('Module failed', 701);
         }
 
@@ -32,7 +37,7 @@ class Status
         $sSQL = 'SELECT word_id, word_token, word, class, type, country_code, ';
         $sSQL .= "operator, search_name_count FROM word WHERE word_token IN (' a')";
         $iWordID = $this->oDB->getOne($sSQL);
-        if (PEAR::isError($iWordID)) {
+        if ($iWordID === false) {
             throw new Exception('Query failed', 703);
         }
         if (!$iWordID) {
@@ -45,7 +50,7 @@ class Status
         $sSQL = 'SELECT EXTRACT(EPOCH FROM lastimportdate) FROM import_status LIMIT 1';
         $iDataDateEpoch = $this->oDB->getOne($sSQL);
 
-        if (PEAR::isError($iDataDateEpoch)) {
+        if ($iDataDateEpoch === false) {
             throw Exception('Data date query failed '.$iDataDateEpoch->getMessage(), 705);
         }
 

--- a/lib/TokenList.php
+++ b/lib/TokenList.php
@@ -85,7 +85,7 @@ class TokenList
         $sSQL = 'SELECT word_id, word_token, word, class, type, country_code,';
         $sSQL .= ' operator, coalesce(search_name_count, 0) as count';
         $sSQL .= ' FROM word WHERE word_token in (';
-        $sSQL .= join(',', array_map('getDBQuoted', $aTokens)).')';
+        $sSQL .= join(',', $oDB->getDBQuotedList($aTokens)).')';
 
         Debug::printSQL($sSQL);
 

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -122,10 +122,6 @@ function showUsage($aSpec, $bExit = false, $sError = false)
 
 function chksql($oSql, $sMsg = false)
 {
-    if (PEAR::isError($oSql)) {
-        fail($sMsg || $oSql->getMessage(), $oSql->userinfo);
-    }
-
     return $oSql;
 }
 
@@ -155,7 +151,7 @@ function repeatWarnings()
 function runSQLScript($sScript, $bfatal = true, $bVerbose = false, $bIgnoreErrors = false)
 {
     // Convert database DSN to psql parameters
-    $aDSNInfo = DB::parseDSN(CONST_Database_DSN);
+    $aDSNInfo = \Nominatim\DB::parseDSN(CONST_Database_DSN);
     if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
     $sCMD = 'psql -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'];
     if (isset($aDSNInfo['hostspec']) && $aDSNInfo['hostspec']) {

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,43 +1,176 @@
 <?php
 
-require_once('DB.php');
+namespace Nominatim;
 
+require_once(CONST_BasePath.'/lib/DatabaseError.php');
 
-function &getDB($bNew = false, $bPersistent = false)
+class DB
 {
-    // Get the database object
-    $oDB = chksql(
-        DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
-        'Failed to establish database connection'
-    );
-    $oDB->setFetchMode(DB_FETCHMODE_ASSOC);
-    $oDB->query("SET DateStyle TO 'sql,european'");
-    $oDB->query("SET client_encoding TO 'utf-8'");
-    $iMaxExecution = ini_get('max_execution_time') * 1000;
-    if ($iMaxExecution > 0) $oDB->query("SET statement_timeout TO $iMaxExecution");
-    return $oDB;
-}
+    public $connection;
 
-function getDBQuoted($s)
-{
-    return "'".pg_escape_string($s)."'";
-}
+    public function __construct($sDSN = CONST_Database_DSN)
+    {
+        $this->sDSN = $sDSN;
+    }
 
-function getArraySQL($a)
-{
-    return 'ARRAY['.join(',', $a).']';
-}
+    public function connect($bNew = false, $bPersistent = true)
+    {
+        $aConnOptions = array(
+                         \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+                         \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                         \PDO::ATTR_PERSISTENT         => $bPersistent
+        );
 
-function getPostgresVersion(&$oDB)
-{
-    $sVersionString = $oDB->getOne('SHOW server_version_num');
-    preg_match('#([0-9]?[0-9])([0-9][0-9])[0-9][0-9]#', $sVersionString, $aMatches);
-    return (float) ($aMatches[1].'.'.$aMatches[2]);
-}
+        // https://secure.php.net/manual/en/ref.pdo-pgsql.connection.php
+        try {
+            $conn = new \PDO($this->sDSN, null, null, $aConnOptions);
+        } catch (\PDOException $e) {
+            $sMsg = 'Failed to establish database connection:' . $e->getMessage();
+            throw new \Nominatim\DatabaseError($sMsg, 500, null, $e->getMessage());
+        }
 
-function getPostgisVersion(&$oDB)
-{
-    $sVersionString = $oDB->getOne('select postgis_lib_version()');
-    preg_match('#^([0-9]+)[.]([0-9]+)[.]#', $sVersionString, $aMatches);
-    return (float) ($aMatches[1].'.'.$aMatches[2]);
+        $conn->exec("SET DateStyle TO 'sql,european'");
+        $conn->exec("SET client_encoding TO 'utf-8'");
+        $iMaxExecution = ini_get('max_execution_time');
+        if ($iMaxExecution > 0) $conn->setAttribute(\PDO::ATTR_TIMEOUT, $iMaxExecution); // seconds
+
+        $this->connection = $conn;
+        return true;
+    }
+
+    // returns the number of rows that were modified or deleted by the SQL
+    // statement. If no rows were affected returns 0.
+    public function exec($sSQL)
+    {
+        $val = null;
+        try {
+            $val = $this->connection->exec($sSQL);
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $val;
+    }
+
+    public function getRow($sSQL)
+    {
+        try {
+            $stmt = $this->connection->query($sSQL);
+            $row = $stmt->fetch();
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $row;
+    }
+
+    public function getOne($sSQL)
+    {
+        try {
+            $stmt = $this->connection->query($sSQL);
+            $row = $stmt->fetch(\PDO::FETCH_NUM);
+            if ($row === false) return false;
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $row[0];
+    }
+
+    public function getAll($sSQL)
+    {
+        try {
+            $stmt = $this->connection->query($sSQL);
+            $rows = $stmt->fetchAll();
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $rows;
+    }
+
+    public function getCol($sSQL)
+    {
+        $aVals = array();
+        try {
+            $stmt = $this->connection->query($sSQL);
+            while ($val = $stmt->fetchColumn(0)) { // returns first column or false
+                $aVals[] = $val;
+            }
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $aVals;
+    }
+
+    public function getAssoc($sSQL)
+    {
+        try {
+            $stmt = $this->connection->query($sSQL);
+            $aList = array();
+            while ($aRow = $stmt->fetch(\PDO::FETCH_NUM)) {
+                $aList[$aRow[0]] = $aRow[1];
+            }
+        } catch (\PDOException $e) {
+            throw new \Nominatim\DatabaseError('Database query failed', 500, null, $e, $sSQL);
+        }
+        return $aList;
+    }
+
+
+    // St. John's Way => 'St. John\'s Way'
+    public function getDBQuoted($sVal)
+    {
+        return $this->connection->quote($sVal);
+    }
+
+    public function getDBQuotedList($aVals)
+    {
+        return array_map(function ($sVal) {
+            return $this->getDBQuoted($sVal);
+        }, $aVals);
+    }
+
+    public function getArraySQL($a)
+    {
+        return 'ARRAY['.join(',', $a).']';
+    }
+
+    public function getLastError()
+    {
+        // https://secure.php.net/manual/en/pdo.errorinfo.php
+        return $this->connection->errorInfo();
+    }
+
+    public function tableExists($sTableName)
+    {
+        $sSQL = 'SELECT count(*) FROM pg_tables WHERE tablename = '.$this->getDBQuoted($sTableName);
+        return ($this->getOne($sSQL) == 1);
+    }
+
+    public function getPostgresVersion()
+    {
+        $sVersionString = $this->getOne('SHOW server_version_num');
+        preg_match('#([0-9]?[0-9])([0-9][0-9])[0-9][0-9]#', $sVersionString, $aMatches);
+        return (float) ($aMatches[1].'.'.$aMatches[2]);
+    }
+
+    public function getPostgisVersion()
+    {
+        $sVersionString = $this->getOne('select postgis_lib_version()');
+        preg_match('#^([0-9]+)[.]([0-9]+)[.]#', $sVersionString, $aMatches);
+        return (float) ($aMatches[1].'.'.$aMatches[2]);
+    }
+
+    public static function parseDSN($sDSN)
+    {
+        // https://secure.php.net/manual/en/ref.pdo-pgsql.connection.php
+        $aInfo = array();
+        if (preg_match('/^pgsql:(.+)/', $sDSN, $aMatches)) {
+            foreach (explode(';', $aMatches[1]) as $sKeyVal) {
+                list($sKey, $sVal) = explode('=', $sKeyVal, 2);
+                if ($sKey == 'host') $sKey = 'hostspec';
+                if ($sKey == 'dbname') $sKey = 'database';
+                if ($sKey == 'user') $sKey = 'username';
+                $aInfo[$sKey] = $sVal;
+            }
+        }
+        return $aInfo;
+    }
 }

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -2,7 +2,6 @@
 
 require_once('init.php');
 require_once('ParameterParser.php');
-require_once('DatabaseError.php');
 require_once(CONST_Debug ? 'DebugHtml.php' : 'DebugNone.php');
 
 /***************************************************************************
@@ -14,9 +13,7 @@ require_once(CONST_Debug ? 'DebugHtml.php' : 'DebugNone.php');
 
 function chksql($oSql, $sMsg = 'Database request failed')
 {
-    if (!PEAR::isError($oSql)) return $oSql;
-
-    throw new Nominatim\DatabaseError($sMsg, 500, null, $oSql);
+    return $oSql;
 }
 
 

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -4,7 +4,7 @@ function fail($sError, $sUserError = false)
 {
     if (!$sUserError) $sUserError = $sError;
     error_log('ERROR: '.$sError);
-    echo $sUserError."\n";
+    var_dump($sUserError)."\n";
     exit(-1);
 }
 

--- a/lib/log.php
+++ b/lib/log.php
@@ -36,8 +36,18 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
             $sUserAgent = $_SERVER['HTTP_USER_AGENT'];
         else $sUserAgent = '';
         $sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
-        $sSQL .= ' values ('.getDBQuoted($sType).','.getDBQuoted($hLog[0]).','.getDBQuoted($hLog[2]);
-        $sSQL .= ','.getDBQuoted($hLog[1]).','.getDBQuoted($sUserAgent).','.getDBQuoted(join(',', $aLanguageList)).','.getDBQuoted($sOutputFormat).','.getDBQuoted($hLog[3]).')';
+        $sSQL .= ' values ('.
+        $sSQL .= join(',', $oDB->getDBQuotedList(array(
+            $sType,
+            $hLog[0],
+            $hLog[2],
+            $hLog[1],
+            $sUserAgent,
+            join(',', $aLanguageList),
+            $sOutputFormat,
+            $hLog[3]
+        )));
+        $sSQL .= ')';
         $oDB->query($sSQL);
     }
 
@@ -53,10 +63,10 @@ function logEnd(&$oDB, $hLog, $iNumResults)
         if (!$aEndTime[1]) $aEndTime[1] = '0';
         $sEndTime = date('Y-m-d H:i:s', $aEndTime[0]).'.'.$aEndTime[1];
 
-        $sSQL = 'update new_query_log set endtime = '.getDBQuoted($sEndTime).', results = '.$iNumResults;
-        $sSQL .= ' where starttime = '.getDBQuoted($hLog[0]);
-        $sSQL .= ' and ipaddress = '.getDBQuoted($hLog[1]);
-        $sSQL .= ' and query = '.getDBQuoted($hLog[2]);
+        $sSQL = 'update new_query_log set endtime = '.$oDB->getDBQuoted($sEndTime).', results = '.$iNumResults;
+        $sSQL .= ' where starttime = '.$oDB->getDBQuoted($hLog[0]);
+        $sSQL .= ' and ipaddress = '.$oDB->getDBQuoted($hLog[1]);
+        $sSQL .= ' and query = '.$oDB->getDBQuoted($hLog[2]);
         $oDB->query($sSQL);
     }
 

--- a/lib/setup/AddressLevelParser.php
+++ b/lib/setup/AddressLevelParser.php
@@ -53,21 +53,21 @@ class AddressLevelParser
      */
     public function createTable($oDB, $sTable)
     {
-        chksql($oDB->query('DROP TABLE IF EXISTS '.$sTable));
+        chksql($oDB->exec('DROP TABLE IF EXISTS '.$sTable));
         $sSql = 'CREATE TABLE '.$sTable;
         $sSql .= '(country_code varchar(2), class TEXT, type TEXT,';
         $sSql .= ' rank_search SMALLINT, rank_address SMALLINT)';
-        chksql($oDB->query($sSql));
+        chksql($oDB->exec($sSql));
 
         $sSql = 'CREATE UNIQUE INDEX ON '.$sTable.'(country_code, class, type)';
-        chksql($oDB->query($sSql));
+        chksql($oDB->exec($sSql));
 
         $sSql = 'INSERT INTO '.$sTable.' VALUES ';
         foreach ($this->aLevels as $aLevel) {
             $aCountries = array();
             if (isset($aLevel['countries'])) {
                 foreach ($aLevel['countries'] as $sCountry) {
-                    $aCountries[$sCountry] = getDBQuoted($sCountry);
+                    $aCountries[$sCountry] = $oDB->getDBQuoted($sCountry);
                 }
             } else {
                 $aCountries['NULL'] = 'NULL';
@@ -75,8 +75,8 @@ class AddressLevelParser
             foreach ($aLevel['tags'] as $sKey => $aValues) {
                 foreach ($aValues as $sValue => $mRanks) {
                     $aFields = array(
-                        getDBQuoted($sKey),
-                        $sValue ? getDBQuoted($sValue) : 'NULL'
+                        $oDB->getDBQuoted($sKey),
+                        $sValue ? $oDB->getDBQuoted($sValue) : 'NULL'
                     );
                     if (is_array($mRanks)) {
                         $aFields[] = (string) $mRanks[0];
@@ -93,6 +93,6 @@ class AddressLevelParser
                 }
             }
         }
-        chksql($oDB->query(rtrim($sSql, ',')));
+        chksql($oDB->exec(rtrim($sSql, ',')));
     }
 }

--- a/lib/setup_functions.php
+++ b/lib/setup_functions.php
@@ -24,15 +24,17 @@ function checkModulePresence()
     $sSQL .= $sModulePath . "/nominatim.so', 'transliteration' LANGUAGE c IMMUTABLE STRICT";
     $sSQL .= ';DROP FUNCTION nominatim_test_import_func(text);';
 
-    $oDB = &getDB();
-    $oResult = $oDB->query($sSQL);
+    $oDB = new \Nominatim\DB();
+    $oDB->connect();
 
     $bResult = true;
-
-    if (PEAR::isError($oResult)) {
+    try {
+        $oDB->exec($sSQL);
+    } catch (\Nominatim\DatabaseError $e) {
         echo "\nERROR: Failed to load nominatim module. Reason:\n";
-        echo $oResult->userinfo . "\n\n";
+        echo $oDB->getLastError()[2] . "\n\n";
         $bResult = false;
     }
+
     return $bResult;
 }

--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -7,7 +7,7 @@ if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 
 // General settings
 @define('CONST_Debug', false);
-@define('CONST_Database_DSN', 'pgsql://@/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
+@define('CONST_Database_DSN', 'pgsql:dbname=nominatim'); // or add ;host=...;port=...;user=...;password=...
 @define('CONST_Database_Web_User', 'www-data');
 @define('CONST_Database_Module_Path', CONST_InstallPath.'/module');
 @define('CONST_Max_Word_Frequency', '50000');

--- a/test/bdd/api/status/failures.feature
+++ b/test/bdd/api/status/failures.feature
@@ -5,7 +5,7 @@ Feature: Status queries against unknown database
     Scenario: Failed status as text
         When sending text status query
         Then a HTTP 500 is returned
-        And the page contents equals "ERROR: No database"
+        And the page contents equals "ERROR: Database connection failed"
 
     Scenario: Failed status as json
         When sending json status query
@@ -13,5 +13,5 @@ Feature: Status queries against unknown database
         And the result is valid json
         And results contain
           | status | message |
-          | 700    | No database |
+          | 700    | Database connection failed |
         And result has not attributes data_updated

--- a/test/bdd/environment.py
+++ b/test/bdd/environment.py
@@ -73,12 +73,14 @@ class NominatimEnvironment(object):
 
     def write_nominatim_config(self, dbname):
         f = open(self.local_settings_file, 'w')
-        f.write("<?php\n  @define('CONST_Database_DSN', 'pgsql://%s:%s@%s%s/%s');\n" %
-                (self.db_user if self.db_user else '',
-                 self.db_pass if self.db_pass else '',
-                 self.db_host if self.db_host else '',
-                 (':' + self.db_port) if self.db_port else '',
-                 dbname))
+        # https://secure.php.net/manual/en/ref.pdo-pgsql.connection.php
+        f.write("<?php\n  @define('CONST_Database_DSN', 'pgsql:dbname=%s%s%s%s%s');\n" %
+                (dbname,
+                 (';host=' + self.db_host) if self.db_host else '',
+                 (';port=' + self.db_port) if self.db_port else '',
+                 (';user=' + self.db_user) if self.db_user else '',
+                 (';password=' + self.db_pass) if self.db_pass else ''
+                 ))
         f.write("@define('CONST_Osm2pgsql_Flatnode_File', null);\n")
         f.close()
 

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -71,7 +71,7 @@ class GenericResponse(object):
                     pass
                 elif h == 'osm':
                     assert_equal(res['osm_type'], row[h][0])
-                    assert_equal(res['osm_id'], row[h][1:])
+                    assert_equal(res['osm_id'], int(row[h][1:]))
                 elif h == 'centroid':
                     x, y = row[h].split(' ')
                     assert_almost_equal(float(y), float(res['lat']))

--- a/test/php/Nominatim/DBTest.php
+++ b/test/php/Nominatim/DBTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Nominatim;
+
+require_once(CONST_BasePath.'/lib/lib.php');
+require_once(CONST_BasePath.'/lib/db.php');
+
+class DBTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testErrorHandling()
+    {
+        $this->expectException(DatabaseError::class);
+        $this->expectExceptionMessage('Failed to establish database connection');
+
+        $oDB = new \Nominatim\DB('pgsql:dbname=abc');
+        $oDB->connect();
+    }
+
+    public function testErrorHandling2()
+    {
+        $this->expectException(DatabaseError::class);
+        $this->expectExceptionMessage('Database query failed');
+
+        $oPDOStub = $this->getMockBuilder(PDO::class)
+                         ->setMethods(array('query', 'quote'))
+                         ->getMock();
+
+        $oPDOStub->method('query')
+                 ->will($this->returnCallback(function ($sVal) {
+                    return "'$sVal'";
+                 }));
+
+        $oPDOStub->method('query')
+                 ->will($this->returnCallback(function () {
+                     throw new \PDOException('ERROR:  syntax error at or near "FROM"');
+                 }));
+
+        $oDB = new \Nominatim\DB('');
+        $oDB->connection = $oPDOStub;
+        $oDB->tableExists('abc');
+    }
+
+    public function testParseDSN()
+    {
+        $this->assertEquals(
+            array(),
+            \Nominatim\DB::parseDSN('')
+        );
+        $this->assertEquals(
+            array(
+             'database' => 'db1',
+             'hostspec' => 'machine1'
+            ),
+            \Nominatim\DB::parseDSN('pgsql:dbname=db1;host=machine1')
+        );
+        $this->assertEquals(
+            array(
+             'database' => 'db1',
+             'hostspec' => 'machine1',
+             'port' => '1234',
+             'username' => 'john',
+             'password' => 'secret'
+            ),
+            \Nominatim\DB::parseDSN('pgsql:dbname=db1;host=machine1;port=1234;user=john;password=secret')
+        );
+    }
+}

--- a/test/php/Nominatim/DatabaseErrorTest.php
+++ b/test/php/Nominatim/DatabaseErrorTest.php
@@ -10,7 +10,7 @@ class DatabaseErrorTest extends \PHPUnit\Framework\TestCase
 
     public function testSqlMessage()
     {
-        $oSqlStub = $this->getMockBuilder(\DB_Error::class)
+        $oSqlStub = $this->getMockBuilder(PDOException::class)
                     ->setMethods(array('getMessage'))
                     ->getMock();
 
@@ -21,24 +21,11 @@ class DatabaseErrorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Sql error', $oErr->getMessage());
         $this->assertEquals(123, $oErr->getCode());
         $this->assertEquals('Unknown table.', $oErr->getSqlError());
-
-        // causes a circular reference warning during dump
-        // $this->assertRegExp('/Mock_DB_Error/', $oErr->getSqlDebugDump());
     }
 
     public function testSqlObjectDump()
     {
         $oErr = new DatabaseError('Sql error', 123, null, array('one' => 'two'));
         $this->assertRegExp('/two/', $oErr->getSqlDebugDump());
-    }
-
-    public function testChksqlThrows()
-    {
-        $this->expectException(DatabaseError::class);
-        $this->expectExceptionMessage('My custom error message');
-        $this->expectExceptionCode(500);
-
-        $oDB = new \DB_Error;
-        $this->assertEquals(false, chksql($oDB, 'My custom error message'));
     }
 }

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -56,9 +56,18 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectOutputRegex('/<p><tt>/');
 
-        $oDbStub = $this->getMockBuilder(\DB::class)
-                        ->setMethods(array('getAll'))
+        $oDbStub = $this->getMockBuilder(Nominatim\DB::class)
+                        ->setMethods(array('getAll', 'getDBQuotedList'))
                         ->getMock();
+
+        $oDbStub->method('getDBQuotedList')
+                ->will($this->returnCallback(function ($aVals) {
+                    return array_map(function ($sVal) {
+                        return "'".$sVal."'";
+                    }, $aVals);
+                }));
+
+
         $oDbStub->method('getAll')
                 ->will($this->returnCallback(function ($sql) {
                     $aResults = array();

--- a/utils/importWikipedia.php
+++ b/utils/importWikipedia.php
@@ -48,7 +48,8 @@ exit;
     $a = array();
     $a[] = 'test';
 
-    $oDB &= getDB();
+    $oDB = new Nominatim\DB();
+    $oDB->connect();
 
     if ($aCMDResult['drop-tables'])
     {
@@ -304,7 +305,9 @@ function _templatesToProperties($aTemplates)
 }
 
 if (isset($aCMDResult['parse-wikipedia'])) {
-    $oDB =& getDB();
+    $oDB = new Nominatim\DB();
+    $oDB->connect();
+
     $sSQL = 'select page_title from content where page_namespace = 0 and page_id %10 = ';
     $sSQL .= $aCMDResult['parse-wikipedia'];
     $sSQL .= ' and (page_content ilike \'%{{Coord%\' or (page_content ilike \'%lat%\' and page_content ilike \'%lon%\'))';
@@ -366,7 +369,9 @@ function nominatimXMLEnd($hParser, $sName)
 
 
 if (isset($aCMDResult['link'])) {
-    $oDB =& getDB();
+    $oDB = new Nominatim\DB();
+    $oDB->connect();
+
     $aWikiArticles = $oDB->getAll("select * from wikipedia_article where language = 'en' and lat is not null and osm_type is null and totalcount < 31 order by importance desc limit 200000");
 
     // If you point this script at production OSM you will be blocked

--- a/utils/query.php
+++ b/utils/query.php
@@ -25,7 +25,9 @@ $aCMDOptions
   );
 getCmdOpt($_SERVER['argv'], $aCMDOptions, $aCMDResult, true, true);
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB;
+$oDB->connect();
+
 $oParams = new Nominatim\ParameterParser($aCMDResult);
 
 if ($oParams->getBool('search')) {

--- a/utils/warm.php
+++ b/utils/warm.php
@@ -18,7 +18,8 @@ require_once(CONST_BasePath.'/lib/Geocode.php');
 require_once(CONST_BasePath.'/lib/PlaceLookup.php');
 require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 
 $bVerbose = $aResult['verbose'];
 

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -23,7 +23,7 @@
     sudo yum install -y postgresql-server postgresql-contrib postgresql-devel \
                         postgis postgis-utils \
                         wget git cmake make gcc gcc-c++ libtool policycoreutils-python \
-                        php-pgsql php php-pear php-pear-DB php-intl libpqxx-devel \
+                        php-pgsql php php-intl libpqxx-devel \
                         proj-epsg bzip2-devel proj-devel libxml2-devel boost-devel \
                         expat-devel zlib-devel
 
@@ -34,7 +34,9 @@
     sudo yum install -y python34-pip python34-setuptools python34-devel \
                         php-phpunit-PHPUnit
     pip3 install --user behave nose pytidylib psycopg2
-    sudo pear install PHP_CodeSniffer
+
+    composer global require "squizlabs/php_codesniffer=*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/Install-on-Ubuntu-16.sh
+++ b/vagrant/Install-on-Ubuntu-16.sh
@@ -29,7 +29,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             libbz2-dev libpq-dev libproj-dev \
                             postgresql-server-dev-9.5 postgresql-9.5-postgis-2.2 \
                             postgresql-contrib-9.5 \
-                            apache2 php php-pgsql libapache2-mod-php php-pear php-db \
+                            apache2 php php-pgsql libapache2-mod-php \
                             php-intl git
 
 # If you want to run the test suite, you need to install the following
@@ -39,7 +39,9 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             python3-psycopg2 python3-tidylib phpunit php-cgi
 
     pip3 install --user behave nose
-    sudo pear install PHP_CodeSniffer
+
+    composer global require "squizlabs/php_codesniffer=*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/Install-on-Ubuntu-18-nginx.sh
+++ b/vagrant/Install-on-Ubuntu-18-nginx.sh
@@ -22,7 +22,7 @@ export DEBIAN_FRONTEND=noninteractive
                             libbz2-dev libpq-dev libproj-dev \
                             postgresql-server-dev-10 postgresql-10-postgis-2.4 \
                             postgresql-contrib-10 \
-                            nginx php-fpm php php-pgsql php-pear php-db \
+                            nginx php-fpm php php-pgsql \
                             php-intl git
 
     export USERNAME=vagrant

--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -29,7 +29,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             libbz2-dev libpq-dev libproj-dev \
                             postgresql-server-dev-10 postgresql-10-postgis-2.4 \
                             postgresql-contrib-10 postgresql-10-postgis-scripts \
-                            apache2 php php-pgsql libapache2-mod-php php-pear php-db \
+                            apache2 php php-pgsql libapache2-mod-php \
                             php-intl git
 
 # If you want to run the test suite, you need to install the following
@@ -39,7 +39,9 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             python3-psycopg2 python3-tidylib phpunit php-cgi
 
     pip3 install --user behave nose
-    sudo pear install PHP_CodeSniffer
+
+    composer global require "squizlabs/php_codesniffer=*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -16,33 +16,15 @@ sudo apt-get install -y -qq libboost-dev libboost-system-dev \
                             libboost-filesystem-dev libexpat1-dev zlib1g-dev libxml2-dev\
                             libbz2-dev libpq-dev libproj-dev \
                             postgresql-server-dev-9.6 postgresql-9.6-postgis-2.4 postgresql-contrib-9.6 \
-                            apache2 php php-pgsql php-intl php-pear
+                            apache2 php php-pgsql php-intl
 
 sudo apt-get install -y -qq python3-dev python3-pip python3-psycopg2 php-cgi
 
 pip3 install --quiet behave nose pytidylib psycopg2-binary
 
-# Travis uses phpenv to support multiple PHP versions. We need to make sure
-# these packages get installed to the phpenv-set PHP (inside /home/travis/.phpenv/),
-# not the system PHP (/usr/bin/php, /usr/share/php/ etc)
-
-# $PHPENV_VERSION and $TRAVIS_PHP_VERSION are unset.
-export PHPENV_VERSION=$(cat /home/travis/.phpenv/version)
-echo $PHPENV_VERSION
-
-# https://github.com/pear/DB
-composer global require "pear/db=1.9.3"
 # https://github.com/squizlabs/PHP_CodeSniffer
 composer global require "squizlabs/php_codesniffer=*"
 sudo ln -s /home/travis/.config/composer/vendor/bin/phpcs /usr/bin/
-
-
-# make sure PEAR.php and DB.php are in the include path
-tee /tmp/travis.php.ini << EOF
-include_path = .:/home/travis/.phpenv/versions/$PHPENV_VERSION/share/pear:/home/travis/.config/composer/vendor/pear/db
-EOF
-phpenv config-add /tmp/travis.php.ini
-
 
 sudo -u postgres createuser -S www-data
 
@@ -77,7 +59,7 @@ make
 tee settings/local.php << EOF
 <?php
  @define('CONST_Website_BaseURL', '/nominatim/');
- @define('CONST_Database_DSN', 'pgsql://@/test_api_nominatim');
+ @define('CONST_Database_DSN', 'pgsql:dbname=test_api_nominatim');
  @define('CONST_Wikipedia_Data_Path', CONST_BasePath.'/test/testdb');
 EOF
 

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -7,7 +7,8 @@ ini_set('memory_limit', '200M');
 
 $sOutputFormat = 'html';
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 
 $sSQL = 'select placex.place_id, country_code,';
 $sSQL .= " name->'name' as name, i.* from placex, import_polygon_delete i";

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -10,13 +10,16 @@ $oParams = new Nominatim\ParameterParser();
 
 $sOutputFormat = $oParams->getSet('format', array('html', 'json'), 'html');
 $aLangPrefOrder = $oParams->getPreferredLanguages();
-$sLanguagePrefArraySQL = 'ARRAY['.join(',', array_map('getDBQuoted', $aLangPrefOrder)).']';
+
 
 $sPlaceId = $oParams->getString('place_id');
 $sOsmType = $oParams->getSet('osmtype', array('N', 'W', 'R'));
 $iOsmId = $oParams->getInt('osmid', -1);
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
+
+$sLanguagePrefArraySQL = $oDB->getArraySQL($oDB->getDBQuotedList($aLangPrefOrder));
 
 if ($sOsmType && $iOsmId > 0) {
     $sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -15,7 +15,8 @@ set_exception_handler_by_format($sOutputFormat);
 // Preferred language
 $aLangPrefOrder = $oParams->getPreferredLanguages();
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 
 $hLog = logStart($oDB, 'place', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 

--- a/website/polygons.php
+++ b/website/polygons.php
@@ -12,7 +12,8 @@ $iDays = $oParams->getInt('days', false);
 $bReduced = $oParams->getBool('reduced', false);
 $sClass = $oParams->getString('class', false);
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 
 $iTotalBroken = (int) chksql($oDB->getOne('select count(*) from import_polygon_error'));
 

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -16,7 +16,8 @@ set_exception_handler_by_format($sOutputFormat);
 // Preferred language
 $aLangPrefOrder = $oParams->getPreferredLanguages();
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 
 $hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 

--- a/website/search.php
+++ b/website/search.php
@@ -6,7 +6,8 @@ require_once(CONST_BasePath.'/lib/Geocode.php');
 require_once(CONST_BasePath.'/lib/output.php');
 ini_set('memory_limit', '200M');
 
-$oDB =& getDB();
+$oDB = new Nominatim\DB();
+$oDB->connect();
 $oParams = new Nominatim\ParameterParser();
 
 $oGeocode = new Nominatim\Geocode($oDB);

--- a/website/status.php
+++ b/website/status.php
@@ -7,9 +7,7 @@ require_once(CONST_BasePath.'/lib/Status.php');
 $oParams = new Nominatim\ParameterParser();
 $sOutputFormat = $oParams->getSet('format', array('text', 'json'), 'text');
 
-$oDB = DB::connect(CONST_Database_DSN, false);
-$oStatus = new Nominatim\Status($oDB);
-
+$oDB = new Nominatim\DB();
 
 if ($sOutputFormat == 'json') {
     header('content-type: application/json; charset=UTF-8');
@@ -17,6 +15,7 @@ if ($sOutputFormat == 'json') {
 
 
 try {
+    $oStatus = new Nominatim\Status($oDB);
     $oStatus->status();
 } catch (Exception $oErr) {
     if ($sOutputFormat == 'json') {


### PR DESCRIPTION
Travis-ci tests pass. I see API unrelated test failures with my test database

```
  api/search/params.feature:48  coordinate search with addressdetails
  => 'Plei Ya Rê, Kon Tum province, Vietnam' != 'Plei Ya Rê, Vietnam'
  api/search/queries.feature:17  House number interpolation even
  api/search/queries.feature:32  House number interpolation odd
  => Additional address parts found: {'state': 'Hamburg'}
```



## CHANGES

* `PEAR` and `PEAR::DB` dependencies no longer required, Debian `php-pgsql`, `libpq-dev` still are. https://secure.php.net/manual/en/pdo.installation.php talks about enabling (removing the `;`) from `;extension=pdo_pgsql` in `php.ini` files, it works for me unchanged though.

* new connection string (DSN) format. The minimal string is 'pgsql:dbname=nominatim', a longer strings looks like `pgsql:dbname=db1;host=machine1;port=1234;user=john;password=secret`. Without host set the connection will be over UNIX socket.

* new `Nominatim::DB` class replacing global namespace. It throws `Nominatim::DatabaseError` on connection or query errors. Wrappers so `$connection` can be private (it isn't yet) and method names to match those of the old DB library.

* `Nominatim::DB` doesn't open a database connection on initialization. It could though if desired. So far - apart from error related tests - any call to `new()` was immediately followed by `connect()`.

* PDO handles empty result sets slightly different. For example `getCol()` used to return false when no row was found. Now it returns an empty array.

* PDO is better to at treating returned numeric values. Where currently we return sometimes return strings to users, now integers are returned.

    1. forward search
https://nominatim.openstreetmap.org/search.php?q=Monaco&format=json&limit=1 vs http://localhost/nominatim/search.php?q=Monaco&format=json&limit=1&addressdetails=1

        - `place_id`, `osm_id` no longer strings
        - bounding box coordinates, `lat`, `lon`, `importance` still float

    2. reverse search comparison
https://nominatim.openstreetmap.org/reverse.php?lat=43.73&lon=7.42&format=jsonv2&addressdetails=1 vs http://localhost/nominatim/reverse.php?lat=43.73&lon=7.42&format=jsonv2&addressdetails=1

        - `place_id`, `osm_id`, `place_rank` no longer strings
        - bounding box coordinates, `lat`, `lon`, `importance` still float

    3. detail page comparison
https://nominatim.openstreetmap.org/details.php?osmtype=R&osmid=393226&format=jsonv2 vs http://localhost/nominatim/details.php?osmtype=R&osmid=393226&format=jsonv2

        - `admin_level` no longer string

    4. With both old and new importance can be "0" (string). The database query returns an integer 0, but the abstraction libraries turn it into a string.

    5. HTML and XML output not affected


## TODO

Possible followups, to be addressed individually (separate PRs)

* Connections are persistent by default, but I didn't know how to implement the `$bNew`. Should be reviewed if we can use a singleton pattern by default.

* We can now use prepared statement handlers. We should add a new second parameter to `Nominatim::DB` query functions to allow setting values.

* `chksql()` functions are empty and should be removed. In 16 calls we set useful error messages, e.g. `chksql($oDB->getAll($sSQL), 'Could not get word tokens.');`
We should add a third parameter to the `Nominatim::DB` query functions to set an error message for exceptions.

* Class naming. `db.php` should be `DB.php`, `DatabaseError` probably `DBError`.

* `Nominatim::DB` doesn't have enough unit tests. Tests for `Nominatim::DB` and `DatabaseError` could be merged.

* Review naming of the `Nominatim::DB` query methods. Currently they follow whatever the old abstraction library used.

* add `Nominatim::DB` method to check if database exists. Currently in `SetupClass::createDB` looks for an exception, a method returning a boolean would be more readable and testable.

* cleanup `Nominatim::DB::parseDSN`. The returned field names might also be outdated. It's only called twice so easy to change the return values.

* There's two methods in `SetupClass` which do parallel (async) processing of SQL files using non-PDO postgresql methods (https://secure.php.net/manual/en/ref.pgsql.php), e.g. `pg_query, pg_send_query, pg_get_result, pg_result_status, PGSQL_COMMAND_OK, ...` Would be better to move that logic into `Nominatim::DB`. Once done we can make `$connection` a private variable.

* `StatusClass::pgExec` is no longer needed

* remove all calls to `$oDB->getLastError()`, it returns an array. Should all be handled via exceptions.
