### PR TITLE
PDO library returns proper boolean. We dont need string comparison

### DIFF
--- a/lib/AddressDetails.php
+++ b/lib/AddressDetails.php
@@ -31,7 +31,7 @@ class AddressDetails
 
     private static function isAddress($aLine)
     {
-        return $aLine['isaddress'] == 't' || $aLine['type'] == 'country_code';
+        return $aLine['isaddress'] || $aLine['type'] == 'country_code';
     }
 
     public function getAddressDetails($bAll = false)
@@ -49,7 +49,7 @@ class AddressDetails
         $sPrevResult = '';
 
         foreach ($this->aAddressLines as $aLine) {
-            if ($aLine['isaddress'] == 't' && $sPrevResult != $aLine['localname']) {
+            if ($aLine['isaddress'] && $sPrevResult != $aLine['localname']) {
                 $sPrevResult = $aLine['localname'];
                 $aParts[] = $sPrevResult;
             }

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -61,7 +61,7 @@
 
 
     function _one_row($aAddressLine){
-        $bNotUsed = (isset($aAddressLine['isaddress']) && $aAddressLine['isaddress'] == 'f');
+        $bNotUsed = !$aAddressLine['isaddress'];
 
         echo '<tr class="' . ($bNotUsed?'notused':'') . '">'."\n";
         echo '  <td class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>')."</td>\n";
@@ -119,7 +119,7 @@
                     if ($aPointDetails['calculated_importance']) {
                         kv('Importance'    , $aPointDetails['calculated_importance'].($aPointDetails['importance']?'':' (estimated)') );
                     }
-                    kv('Coverage'        , ($aPointDetails['isarea']=='t'?'Polygon':'Point') );
+                    kv('Coverage'        , ($aPointDetails['isarea']?'Polygon':'Point') );
                     kv('Centre Point'    , $aPointDetails['lat'].','.$aPointDetails['lon'] );
                     kv('OSM'             , osmLink($aPointDetails) );
                     if ($aPointDetails['wikipedia'])

--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -33,7 +33,7 @@ if ($aPointDetails['icon']) {
 $aPlaceDetails['rank_address'] = (int) $aPointDetails['rank_address'];
 $aPlaceDetails['rank_search'] = (int) $aPointDetails['rank_search'];
 
-$aPlaceDetails['isarea'] = ($aPointDetails['isarea'] == 't');
+$aPlaceDetails['isarea'] = $aPointDetails['isarea'];
 $aPlaceDetails['centroid'] = array(
                               'type' => 'Point',
                               'coordinates' => array( (float) $aPointDetails['lon'], (float) $aPointDetails['lat'] )

--- a/utils/update.php
+++ b/utils/update.php
@@ -352,7 +352,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
         $sBatchEnd = $aLastState['lastimportdate'];
         $iEndSequence = $aLastState['sequence_id'];
 
-        if ($aLastState['indexed'] == 't') {
+        if ($aLastState['indexed']) {
             // Sleep if the update interval has not yet been reached.
             $fNextUpdate = $aLastState['unix_ts'] + CONST_Replication_Update_Interval;
             if ($fNextUpdate > $fStartTime) {

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -121,7 +121,7 @@ if (!empty($aParentOfLines)) {
             echo '<div class="line">';
             echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
             echo ' (';
-            echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
+            echo '<span class="area">'.($aAddressLine['isarea']?'Polygon':'Point').'</span>';
             if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' '.osmLink($aAddressLine).'</span>';
             echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
             echo ', '.$aAddressLine['area'];


### PR DESCRIPTION
New database abstraction is better returning values in their correct type.

I noticed when the output of the /details page had the grayed-out columns reversed (see screenshot). Grepped for `'t'` and `'f'` in all files.

Test case for the `update.php` logic:
```
vagrant@vagrant:~/build$ php -r 'require_once("settings/settings.php");require_once(CONST_BasePath."/lib/init-cmd.php"); $oDB = new Nominatim\DB(); $oDB->connect(); $aLastState = $oDB->getRow("SELECT *, EXTRACT (EPOCH FROM lastimportdate) as unix_ts FROM import_status"); var_dump($aLastState["indexed"]);'
bool(true)
```

![image](https://user-images.githubusercontent.com/3727288/55412594-07f57f80-5568-11e9-88cd-33a2118f0567.png)
