### PR TITLE
checkModulePresence now raises exception instead of its callers

### DIFF
--- a/lib/DB.php
+++ b/lib/DB.php
@@ -229,12 +229,6 @@ class DB
         return 'ARRAY['.join(',', $a).']';
     }
 
-    public function getLastError()
-    {
-        // https://secure.php.net/manual/en/pdo.errorinfo.php
-        return $this->connection->errorInfo();
-    }
-
     /**
      * Check if a table exists in the database. Returns true if it does.
      *

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -144,9 +144,7 @@ class SetupFunctions
         }
 
         // Try accessing the C module, so we know early if something is wrong
-        if (!checkModulePresence()) {
-            fail('error loading nominatim.so module');
-        }
+        checkModulePresence(); // raises exception on failure
 
         if (!file_exists(CONST_ExtraDataPath.'/country_osm_grid.sql.gz')) {
             echo 'Error: you need to download the country_osm_grid first:';
@@ -227,11 +225,9 @@ class SetupFunctions
     {
         info('Create Functions');
 
-        // Try accessing the C module, so we know eif something is wrong
-        // update.php calls this function
-        if (!checkModulePresence()) {
-            fail('error loading nominatim.so module');
-        }
+        // Try accessing the C module, so we know early if something is wrong
+        checkModulePresence(); // raises exception on failure
+
         $this->createSqlFunctions();
     }
 

--- a/lib/setup_functions.php
+++ b/lib/setup_functions.php
@@ -17,8 +17,9 @@ function checkInFile($sOSMFile)
 
 function checkModulePresence()
 {
-    // Try accessing the C module, so we know early if something is wrong
-    // and can simply error out.
+    // Try accessing the C module, so we know early if something is wrong.
+    // Raises Nominatim\DatabaseError on failure
+
     $sModulePath = CONST_Database_Module_Path;
     $sSQL = "CREATE FUNCTION nominatim_test_import_func(text) RETURNS text AS '";
     $sSQL .= $sModulePath . "/nominatim.so', 'transliteration' LANGUAGE c IMMUTABLE STRICT";
@@ -26,15 +27,5 @@ function checkModulePresence()
 
     $oDB = new \Nominatim\DB();
     $oDB->connect();
-
-    $bResult = true;
-    try {
-        $oDB->exec($sSQL);
-    } catch (\Nominatim\DatabaseError $e) {
-        echo "\nERROR: Failed to load nominatim module. Reason:\n";
-        echo $oDB->getLastError()[2] . "\n\n";
-        $bResult = false;
-    }
-
-    return $bResult;
+    $oDB->exec($sSQL, null, 'Database server failed to load '.$sModulePath.'/nominatim.so module');
 }

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -84,9 +84,7 @@ if ($aCMDResult['setup-db'] || $aCMDResult['all']) {
 }
 
 // Try accessing the C module, so we know early if something is wrong
-if (!checkModulePresence()) {
-    fail('error loading nominatim.so module');
-}
+checkModulePresence(); // raises exception on failure
 
 if ($aCMDResult['import-data'] || $aCMDResult['all']) {
     $bDidSomething = true;


### PR DESCRIPTION
* remove method `Nominatim::DB::getLastError`. Returned an numbered array, was only used once. Should be obsolete with the other DB methods throwing exceptions.

* `checkModulePresence()` now raises exception on failure. Previously it returned boolean and all caller raised an exception on false.

* Added "database server" to error message to make it a bit more clear who is trying to access the file.

Example error output
```
~/build$ php -r 'require_once("settings/settings.php");require_once(CONST_BasePath."/lib/init-cmd.php");require_once(CONST_BasePath."/lib/setup_functions.php"); var_dump(checkModulePresence());'
PHP Fatal error:  Uncaught Nominatim\DatabaseError: [500]: Database server failed to load /some_test_path/nominatim.so module
```