### PR TITLE
travis-CI: use PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ git:
 env:
   - TEST_SUITE=tests
   - TEST_SUITE=monaco
+before_install:
+  - phpenv global 7.1
 install:
   - vagrant/install-on-travis-ci.sh
 before_script:
@@ -19,7 +21,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/
   - if [[ $TEST_SUITE == "tests" ]]; then phpcs --report-width=120 . ; fi
   - cd $TRAVIS_BUILD_DIR/test/php
-  - if [[ $TEST_SUITE == "tests" ]]; then phpunit ./ ; fi
+  - if [[ $TEST_SUITE == "tests" ]]; then /usr/bin/phpunit ./ ; fi
   - cd $TRAVIS_BUILD_DIR/test/bdd
   - # behave --format=progress3 api
   - if [[ $TEST_SUITE == "tests" ]]; then behave -DREMOVE_TEMPLATE=1 --format=progress3 db ; fi

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -26,6 +26,9 @@ pip3 install --quiet behave nose pytidylib psycopg2-binary
 composer global require "squizlabs/php_codesniffer=*"
 sudo ln -s /home/travis/.config/composer/vendor/bin/phpcs /usr/bin/
 
+composer global require "phpunit/phpunit=7.*"
+sudo ln -s /home/travis/.config/composer/vendor/bin/phpunit /usr/bin/
+
 sudo -u postgres createuser -S www-data
 
 # Make sure that system servers can read from the home directory:


### PR DESCRIPTION
fixes https://github.com/openstreetmap/Nominatim/issues/1357

Travis defaults to the latest PHP version (7.2) which causes new test failures. We want to stay on 7.1 for now, otherwise we'd introduce PHP syntax incompatible to PHP 5.x. We can switch to 7.2 once we discontinue Nominatim PHP 5.x support.

PHPUnit 7 is required for PHP 7.1 https://secure.php.net/supported-versions.php so PHPUnit had to be downgraded from the default version 8 as well. https://phpunit.de/supported-versions.html