### PR TITLE
register shutdown function to handle out-of-memory errors

### DIFF
--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -21,6 +21,7 @@ function exception_handler_html($exception)
     http_response_code($exception->getCode());
     header('Content-type: text/html; charset=UTF-8');
     include(CONST_BasePath.'/lib/template/error-html.php');
+    exit();
 }
 
 function exception_handler_json($exception)
@@ -28,6 +29,7 @@ function exception_handler_json($exception)
     http_response_code($exception->getCode());
     header('Content-type: application/json; charset=utf-8');
     include(CONST_BasePath.'/lib/template/error-json.php');
+    exit();
 }
 
 function exception_handler_xml($exception)
@@ -36,17 +38,51 @@ function exception_handler_xml($exception)
     header('Content-type: text/xml; charset=utf-8');
     echo '<?xml version="1.0" encoding="UTF-8" ?>'."\n";
     include(CONST_BasePath.'/lib/template/error-xml.php');
+    exit();
+}
+
+function shutdown_exception_handler_html()
+{
+    $error = error_get_last();
+    if ($error !== null && $error['type'] === E_ERROR) {
+        exception_handler_html(new Exception($error['message'], 500));
+    }
+}
+
+function shutdown_exception_handler_xml()
+{
+    $error = error_get_last();
+    if ($error !== null && $error['type'] === E_ERROR) {
+        exception_handler_xml(new Exception($error['message'], 500));
+    }
+}
+
+function shutdown_exception_handler_json()
+{
+    $error = error_get_last();
+    if ($error !== null && $error['type'] === E_ERROR) {
+        exception_handler_json(new Exception($error['message'], 500));
+    }
 }
 
 
-function set_exception_handler_by_format($sFormat = 'html')
+function set_exception_handler_by_format($sFormat = null)
 {
-    if ($sFormat == 'html') {
+    // Multiple calls to register_shutdown_function will cause multiple callbacks
+    // to be executed, we only want the last executed. Thus we don't want to register
+    // one by default without an explicit $sFormat set.
+
+    if (!isset($sFormat)) {
         set_exception_handler('exception_handler_html');
+    } elseif ($sFormat == 'html') {
+        set_exception_handler('exception_handler_html');
+        register_shutdown_function('shutdown_exception_handler_html');
     } elseif ($sFormat == 'xml') {
         set_exception_handler('exception_handler_xml');
+        register_shutdown_function('shutdown_exception_handler_xml');
     } else {
         set_exception_handler('exception_handler_json');
+        register_shutdown_function('shutdown_exception_handler_json');
     }
 }
 // set a default


### PR DESCRIPTION
fixes https://github.com/openstreetmap/Nominatim/issues/1385

Throwing errors inside the callback isn't allowed, calling our exception handler works.

To avoid code duplication I also tried callbacks using `call_user_func('exception_handler_'.$sOutFormat, ...` but overall it became less readable.

With the XML format generating the output can cause a second out-of-memory error, leading to HTTP 500 response with empty body. It only happens sometimes.