### PR TITLE
exclude postcode ranges separated by colon from centre point calculation

### DIFF
--- a/sql/update-postcodes.sql
+++ b/sql/update-postcodes.sql
@@ -6,7 +6,7 @@ SELECT country_code,
        ST_Centroid(ST_Collect(ST_Centroid(geometry))) as centroid
   FROM placex
  WHERE address ? 'postcode'
-       AND address->'postcode' NOT SIMILAR TO '%(,|;)%'
+       AND address->'postcode' NOT SIMILAR TO '%(,|;|:)%'
        AND geometry IS NOT null
 GROUP BY country_code, pc;
 


### PR DESCRIPTION
Nominatim database contains 9014 postcodes with ":", 8925 of those are in the United States.

```
SELECT  count(*) FROM placex WHERE address->'postcode' SIMILAR TO '%:%';
```

Those come from TIGER import and unrealistic to change all the values. We already exclude semicolon.

https://www.openstreetmap.org/way/19184318 `tiger:zip_left => 43011:43334`
https://www.openstreetmap.org/way/527394443 `tiger:zip_left => 46743:46815; 46743`
https://www.openstreetmap.org/way/11630062 `tiger:zip_left => 07047:07087:07093; 07087`

The non-US postcodes are either typos, bad data (e.g. phone numbers) or prefixes (in Cameroon).