### PR TITLE
Remove more places from address ranking

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -83,6 +83,16 @@
           "neighbourhood" : [30, 0]
       }
   }
+},
+{ "countries" : [ "de" ],
+  "tags" : {
+      "place" : {
+          "county" : [12, 0]
+      },
+      "boundary" : {
+          "administrative5" : [10, 0]
+      }
+  }
 }
 ]
 

--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -3,8 +3,8 @@
       "place" : {
           "sea" : [2, 0],
           "continent" : [2, 0],
-          "country" : [4, 4],
-          "state" : [8, 8],
+          "country" : [4, 0],
+          "state" : [8, 0],
           "region" : [18, 0],
           "county" : 12,
           "city" : 16,

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -887,11 +887,7 @@ BEGIN
     END IF;
 
     -- some postcorrections
-    IF NEW.class = 'place' THEN
-      IF NEW.type in ('continent', 'sea', 'country', 'state') AND NEW.osm_type = 'N' THEN
-        NEW.rank_address := 0;
-      END IF;
-    ELSEIF NEW.class = 'waterway' AND NEW.osm_type = 'R' THEN
+    IF NEW.class = 'waterway' AND NEW.osm_type = 'R' THEN
         -- Slightly promote waterway relations so that they are processed
         -- before their members.
         NEW.rank_search := NEW.rank_search - 1;
@@ -907,11 +903,6 @@ BEGIN
   IF NEW.rank_search < 4 THEN
     NEW.country_code := NULL;
   END IF;
-
--- Block import below rank 22
---  IF NEW.rank_search > 22 THEN
---    RETURN NULL;
---  END IF;
 
   --DEBUG: RAISE WARNING 'placex_insert:END: % % % %',NEW.osm_type,NEW.osm_id,NEW.class,NEW.type;
 

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -220,8 +220,8 @@ Feature: Import into placex
           | R21    | 30          | 30 |
           | R22    | 30          | 30 |
           | R23    | 30          | 30 |
-          | R40    | 4           | 4 |
-          | R41    | 8           | 8 |
+          | R40    | 4           | 0 |
+          | R41    | 8           | 0 |
 
     Scenario: search and address ranks for highways correctly assigned
         Given the scene roads-with-pois


### PR DESCRIPTION
Gets rid of the hard-coded expection for place nodes and sets the address rank generally via the address level config instead. That means only administrative boundaries are now used at that level in addresses.

For Germany also remove place=county (counties are complete at boundary level) and Regierungsbezirke (admin_level=5) because nobody would ever use them in an address or search.
