### PR TITLE
Fix DB log

### DIFF
--- a/lib/log.php
+++ b/lib/log.php
@@ -36,7 +36,7 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
             $sUserAgent = $_SERVER['HTTP_USER_AGENT'];
         else $sUserAgent = '';
         $sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
-        $sSQL .= ' values ('.
+        $sSQL .= ' values (';
         $sSQL .= join(',', $oDB->getDBQuotedList(array(
             $sType,
             $hLog[0],

--- a/lib/log.php
+++ b/lib/log.php
@@ -48,7 +48,7 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
             $hLog[3]
         )));
         $sSQL .= ')';
-        $oDB->query($sSQL);
+        $oDB->exec($sSQL);
     }
 
     return $hLog;
@@ -67,7 +67,7 @@ function logEnd(&$oDB, $hLog, $iNumResults)
         $sSQL .= ' where starttime = '.$oDB->getDBQuoted($hLog[0]);
         $sSQL .= ' and ipaddress = '.$oDB->getDBQuoted($hLog[1]);
         $sSQL .= ' and query = '.$oDB->getDBQuoted($hLog[2]);
-        $oDB->query($sSQL);
+        $oDB->exec($sSQL);
     }
 
     if (CONST_Log_File) {


### PR DESCRIPTION
When I set `@define('CONST_Log_DB', true);` in `build/settings/local.php`, I'm getting the following error on path `/nominatim/reverse.php?format=html&lat=20&lon=0&zoom=18&debug=1`:

```
Internal Server Error

Nominatim has encountered an error with your request.
Details
Call to undefined method Nominatim\DB::query()

Exception Error thrown in /srv/nominatim/Nominatim/lib/log.php(51).
Stack trace

#0 /srv/nominatim/Nominatim/website/search.php(64): logStart(Object(Nominatim\DB), 'search', false, Array)
#1 /srv/nominatim/Nominatim/build/website/search.php(3): require_once('/srv/nominatim/...')
#2 {main}
```
After I changed to call the right method, I was getting a second error too:

```
Internal Server Error

Nominatim has encountered an error with your request.
Details
syntax error, unexpected ','

Exception ParseError thrown in /srv/nominatim/Nominatim/lib/log.php(39).
Stack trace

#0 /srv/nominatim/Nominatim/build/website/search.php(3): require_once()
#1 {main}
```
This PR fixes these DB log related bugs.