### PR TITLE
Minor change on lookup endpoint doc

### DIFF
--- a/docs/api/Lookup.md
+++ b/docs/api/Lookup.md
@@ -19,7 +19,7 @@ Additional optional parameters are explained below.
 
 ### Output format
 
-* `format=[html|xml|json|jsonv2|geojson|geocodejson]`
+* `format=[xml|json|geojson]`
 
 See [Place Output Formats](Output.md) for details on each format. (Default: xml)
 


### PR DESCRIPTION
Fix documentation about lookup endpoint on output formats available on filter `format`