### PR TITLE
In install instruction make clear behave,phpunit,phpcs are optional

### DIFF
--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -27,14 +27,19 @@
                         proj-epsg bzip2-devel proj-devel libxml2-devel boost-devel \
                         expat-devel zlib-devel
 
-# If you want to run the test suite, you need to install the following
-# additional packages:
+
+# Optional Software
+# --------------------------------
+#
+# If you want to help with the development of Nominatim and run the
+# test suite, you need to install the following additional packages:
 
 #DOCS:    :::sh
     sudo yum install -y python34-pip python34-setuptools python34-devel \
                         php-phpunit-PHPUnit
     pip3 install --user behave nose pytidylib psycopg2
 
+    # Requires Composer package manager https://getcomposer.org/download/
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 

--- a/vagrant/Install-on-Ubuntu-16.sh
+++ b/vagrant/Install-on-Ubuntu-16.sh
@@ -32,14 +32,18 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             apache2 php php-pgsql libapache2-mod-php \
                             php-intl git
 
-# If you want to run the test suite, you need to install the following
-# additional packages:
+# Optional Software
+# --------------------------------
+#
+# If you want to help with the development of Nominatim and run the
+# test suite, you need to install the following additional packages:
 
     sudo apt-get install -y python3-setuptools python3-dev python3-pip \
                             python3-psycopg2 python3-tidylib phpunit php-cgi
 
     pip3 install --user behave nose
 
+    # Requires Composer package manager https://getcomposer.org/download/
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 

--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -32,14 +32,18 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             apache2 php php-pgsql libapache2-mod-php \
                             php-intl git
 
-# If you want to run the test suite, you need to install the following
-# additional packages:
+# Optional Software
+# --------------------------------
+#
+# If you want to help with the development of Nominatim and run the
+# test suite, you need to install the following additional packages:
 
     sudo apt-get install -y python3-setuptools python3-dev python3-pip \
                             python3-psycopg2 python3-tidylib phpunit php-cgi
 
     pip3 install --user behave nose
 
+    # Requires Composer package manager https://getcomposer.org/download/
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/Nominatim/issues/1425

Make it more clear the test suite software packages are optional. Add a link how to install PHP composer as not Debian (apt-get) package exists.

The comment inside the code block renders fine in mkdocs
![image](https://user-images.githubusercontent.com/3727288/61554311-ee1b7200-aa5c-11e9-97c4-18e804efcd6e.png)
