### PR TITLE
during TIGER import skip records with negative house number range

### DIFF
--- a/sql/tiger_import_start.sql
+++ b/sql/tiger_import_start.sql
@@ -26,6 +26,11 @@ BEGIN
     endnumber = in_startnumber;
   END IF;
 
+  IF startnumber < 0 THEN
+    RAISE WARNING 'Negative house number range (% to %) on %, %', startnumber, endnumber, in_street, in_isin;
+    RETURN 0;
+  END IF;
+
   numberrange := endnumber - startnumber;
 
   IF (interpolationtype = 'odd' AND startnumber%2 = 0) OR (interpolationtype = 'even' AND startnumber%2 = 1) THEN


### PR DESCRIPTION
For https://github.com/openstreetmap/Nominatim/issues/1429

I ran a full reimport and the `location_property_tiger` table shows 204 less rows as expected. 

On my setup `reverse.php?format=jsonv2&lat=41.2372571819472&lon=-86.7041228137963` now returns 

```
    "type": "house",
    "addresstype": "place",
    "name": null,
    "display_name": "300, West 450 South, Toto, Starke County, Indiana, 46366, USA",
    "address": {
        "house_number": "300",
        "road": "West 450 South",
        "hamlet": "Toto",
        "county": "Starke County",
        "state": "Indiana",
        "postcode": "46366",
        "country": "USA",
        "country_code": "us"
    },
```
