### PR TITLE
Require python 3

### DIFF
--- a/data-sources/us-tiger/README.md
+++ b/data-sources/us-tiger/README.md
@@ -9,9 +9,7 @@ Replace '2018' with the current year throughout.
   1. Install the GDAL library and python bindings and the unzip tool
 
         # Ubuntu:
-        sudo apt-get install python-gdal unzip
-        # CentOS:
-        sudo yum install gdal-python unzip
+        sudo apt-get install python3-gdal unzip
 
   2. Get the TIGER 2018 data. You will need the EDGES files
      (3,233 zip files, 11GB total).
@@ -22,8 +20,7 @@ Replace '2018' with the current year throughout.
 
         cd data-sources/us-tiger
         ./convert.sh <input-path> <output-path>
-        
+
   4. Maybe: package the created files
-  
+
         tar -czf tiger2018-nominatim-preprocessed.tar.gz tiger
-        

--- a/data-sources/us-tiger/tiger_address_convert.py
+++ b/data-sources/us-tiger/tiger_address_convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Tiger road data to OSM conversion script
 # Creates Karlsruhe-style address ways beside the main way
 # based on the Massachusetts GIS script by christopher schmidt
@@ -164,7 +164,7 @@ def parse_shp_for_geom_and_tags( filename ):
         if (statefp != None) and (countyfp != None):
             county_name = county_fips_data.get(statefp + '' + countyfp)
             if county_name:
-                tags["tiger:county"] = county_name.encode("utf-8")
+                tags["tiger:county"] = county_name
 
         # tlid = poFeature.GetField("TLID")
         # if tlid != None:

--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -220,14 +220,14 @@ For a list of other methods see the output of `./utils/update.php --help`.
 
 #### Installing the newest version of Pyosmium
 
-It is recommended to install Pyosmium via pip. Run (as the same user who
-will later run the updates):
+It is recommended to install Pyosmium via pip. Make sure to use python3.
+Run (as the same user who will later run the updates):
 
 ```sh
-pip install --user osmium
+pip3 install --user osmium
 ```
 
-Nominatim needs a tool called `pyosmium-get-updates`, which comes with
+Nominatim needs a tool called `pyosmium-get-updates` which comes with
 Pyosmium. You need to tell Nominatim where to find it. Add the
 following line to your `settings/local.php`:
 

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -50,7 +50,7 @@ For running Nominatim:
 
 For running continuous updates:
 
-  * [pyosmium](https://osmcode.org/pyosmium/)
+  * [pyosmium](https://osmcode.org/pyosmium/) (with Python 3)
 
 ### Hardware
 

--- a/utils/check_server_for_updates.py
+++ b/utils/check_server_for_updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 from osmium.replication import server

--- a/utils/osm_file_date.py
+++ b/utils/osm_file_date.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import osmium
 import sys


### PR DESCRIPTION
Python 2 is EOL by the end of year and all distributions should ship python3 properly by now. So let's retire Python2.

I couldn't find a python3-gdal package for CentOS, so I've remove the instructions in the TIGER readme.