### PR TITLE
lookup endpoint returns boundingbox

### DIFF
--- a/test/bdd/api/lookup/simple.feature
+++ b/test/bdd/api/lookup/simple.feature
@@ -18,3 +18,16 @@ Feature: Places by osm_type and osm_id Tests
     Scenario: address lookup for non-existing or invalid node, way, relation
         When sending xml lookup query for X99,,N0,nN158845944,ABC,,W9
         Then exactly 0 results are returned
+
+    Scenario Outline: Boundingbox is returned
+        When sending <format> lookup query for N3284625766,W6065798
+        Then exactly 2 results are returned
+        And result 0 has bounding box in -32.812,-32.811,-56.509,-56.508
+        And result 1 has bounding box in 47.14,47.15,9.51,9.53
+
+    Examples:
+      | format |
+      | json |
+      | jsonv2 |
+      | geojson |
+      | xml |

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -53,6 +53,18 @@ foreach ($aOsmIds as $sItem) {
                 unset($oResult['langaddress']);
                 $oResult['name'] = $oPlace['langaddress'];
             }
+
+            $aOutlineResult = $oPlaceLookup->getOutlines(
+                $oPlace['place_id'],
+                $oPlace['lon'],
+                $oPlace['lat'],
+                Nominatim\ClassTypes\getProperty($oPlace, 'defdiameter', 0.0001)
+            );
+
+            if ($aOutlineResult) {
+                $oResult = array_merge($oResult, $aOutlineResult);
+            }
+
             $aSearchResults[] = $oResult;
         }
     }


### PR DESCRIPTION
fixes https://github.com/openstreetmap/Nominatim/issues/1449

[geocodejson specification](https://github.com/geocoders/geocodejson-spec/tree/master/draft)  doesn't list bounding box fields.