### PR TITLE
Fix python shebang following PEP 394 recommendation

### DIFF
--- a/utils/check_server_for_updates.py
+++ b/utils/check_server_for_updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from osmium.replication import server

--- a/utils/osm_file_date.py
+++ b/utils/osm_file_date.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import osmium
 import sys


### PR DESCRIPTION
This PR fix `ModuleNotFoundError: No module named 'osmium'` error when trying to run `./utils/update.php --import-osmosis-all` from inside a conda environment.

The change is based on [PEP 394 recommendation](https://www.python.org/dev/peps/pep-0394/#recommendation) on how to write shebangs in python.