### PR TITLE
on --drop warn on non-existing tables, dont croak

### DIFF
--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -725,9 +725,7 @@ class SetupFunctions
         }
         foreach ($aDropTables as $sDrop) {
             if ($this->bVerbose) echo "Dropping table $sDrop\n";
-            $this->oDB->exec("DROP TABLE $sDrop CASCADE");
-            // ignore warnings/errors as they might be caused by a table having
-            // been deleted already by CASCADE
+            $this->oDB->exec("DROP TABLE IF EXISTS $sDrop CASCADE");
         }
 
         if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {


### PR DESCRIPTION
Closes https://github.com/openstreetmap/Nominatim/issues/1483

Tested on a local copy. Before
```
nominatim=# SELECT count(*) FROM pg_tables;
 count
-------
  1187
```
`./utils/setup.php --drop` runs and prints no errors.
After
```
nominatim=# SELECT count(*) FROM pg_tables;
 count
-------
   418
```