### PR TITLE
documentation: viewbox parameter as lon,lat instead of x,y

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -109,7 +109,7 @@ the search to return other, less accurate, matches (if possible).
 Limit the number of returned results. (Default: 10, Maximum: 50)
 
 
-* `viewbox=<x1>,<y1>,<x2>,<y2>`
+* `viewbox=<lon1>,<lat1>,<lon2>,<lat2>`
 
 The preferred area to find search results. Any two corner points of the box
 are accepted in any order as long as they span a real box.


### PR DESCRIPTION
Following https://github.com/openstreetmap/Nominatim/issues/1512#issuecomment-537575270 and we don't use `x`, `y` for any other parameter. Of course user might still mix up what latitude and what longitude is.