### PR TITLE
documentation: add note what x,y mean for viewbox parameter

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -112,7 +112,8 @@ Limit the number of returned results. (Default: 10, Maximum: 50)
 * `viewbox=<x1>,<y1>,<x2>,<y2>`
 
 The preferred area to find search results. Any two corner points of the box
-are accepted in any order as long as they span a real box.
+are accepted in any order as long as they span a real box. `x` is longitude,
+`y` is latitude.
 
 
 * `bounded=[0|1]`


### PR DESCRIPTION
Following https://github.com/openstreetmap/Nominatim/issues/1512#issuecomment-537575270 added a note what `x` and `y` mean. An easy/common mistake to mix them up, I certainly have made the mistake before.