### PR TITLE
Use ExtraDataPath for country grid

### DIFF
--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -137,7 +137,7 @@ class SetupFunctions
             exit(1);
         }
         $this->pgsqlRunScriptFile(CONST_BasePath.'/data/country_name.sql');
-        $this->pgsqlRunScriptFile(CONST_BasePath.'/data/country_osm_grid.sql.gz');
+        $this->pgsqlRunScriptFile(CONST_ExtraDataPath.'/country_osm_grid.sql.gz');
         $this->pgsqlRunScriptFile(CONST_BasePath.'/data/gb_postcode_table.sql');
         $this->pgsqlRunScriptFile(CONST_BasePath.'/data/us_postcode_table.sql');
 


### PR DESCRIPTION
This directory is already printed in the warning when country grid is missing, but
the file itself was being loaded from a different dir.