### PR TITLE
Handle zero in getCol()

### DIFF
--- a/lib/DB.php
+++ b/lib/DB.php
@@ -135,7 +135,7 @@ class DB
         try {
             $stmt = $this->getQueryStatement($sSQL, $aInputVars, $sErrMessage);
 
-            while ($val = $stmt->fetchColumn(0)) { // returns first column or false
+            while (($val = $stmt->fetchColumn(0)) !== false) { // returns first column or false
                 $aVals[] = $val;
             }
         } catch (\PDOException $e) {


### PR DESCRIPTION
getCol() method did not distinguish between value 0 being returned and no more values in the result.
When running with no-parititions flag, only partition 0 is used, so a query `select distinct partition from placex` returns 0,
which getCol() mishandles and returns an empty array, resulting in no partition tables created and incorrect partition functions.