### PR TITLE
Addresses with housenumber 0 are found

### DIFF
--- a/lib/AddressDetails.php
+++ b/lib/AddressDetails.php
@@ -76,14 +76,14 @@ class AddressDetails
                 $bFallback = true;
             }
 
-            $sName = false;
-            if (isset($aLine['localname']) && $aLine['localname']) {
+            $sName = null;
+            if (isset($aLine['localname']) && $aLine['localname']!=='') {
                 $sName = $aLine['localname'];
-            } elseif (isset($aLine['housenumber']) && $aLine['housenumber']) {
+            } elseif (isset($aLine['housenumber']) && $aLine['housenumber']!=='') {
                 $sName = $aLine['housenumber'];
             }
 
-            if ($sName) {
+            if (isset($sName)) {
                 $sTypeLabel = strtolower(isset($aTypeLabel['simplelabel']) ? $aTypeLabel['simplelabel'] : $aTypeLabel['label']);
                 $sTypeLabel = str_replace(' ', '_', $sTypeLabel);
                 if (!isset($aAddress[$sTypeLabel])
@@ -97,6 +97,7 @@ class AddressDetails
                 }
             }
         }
+
         return $aAddress;
     }
 

--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -447,8 +447,8 @@ class SearchDescription
                 $iLimit
             );
 
-            //now search for housenumber, if housenumber provided
-            if ($this->sHouseNumber && !empty($aResults)) {
+            // Now search for housenumber, if housenumber provided. Can be zero.
+            if (($this->sHouseNumber || $this->sHouseNumber === '0') && !empty($aResults)) {
                 // Downgrade the rank of the street results, they are missing
                 // the housenumber.
                 foreach ($aResults as $oRes) {

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -64,7 +64,7 @@
         $bNotUsed = isset($aAddressLine['isaddress']) && !$aAddressLine['isaddress'];
 
         echo '<tr class="' . ($bNotUsed?'notused':'') . '">'."\n";
-        echo '  <td class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>')."</td>\n";
+        echo '  <td class="name">'.(trim($aAddressLine['localname'])!==null?$aAddressLine['localname']:'<span class="noname">No Name</span>')."</td>\n";
         echo '  <td>' . $aAddressLine['class'].':'.$aAddressLine['type'] . "</td>\n";
         echo '  <td>' . osmLink($aAddressLine) . "</td>\n";
         echo '  <td>' . (isset($aAddressLine['rank_address']) ? $aAddressLine['rank_address'] : '') . "</td>\n";


### PR DESCRIPTION
I identified the pieces of logic to get 0 housenumbers working. I don't know if it's elegant enough yet.

```
$curl -s 'http://localhost:8089/nominatim/search.php?q=0+Tiffany+Crescent%2C+ottawa&addressdetails=1&format=jsonv2' | jq '.'
[
  {
    "place_id": 435577,
    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
    "osm_type": "way",
    "osm_id": 473030197,
    "boundingbox": [
      "45.324497",
      "45.324672",
      "-75.904572",
      "-75.904297"
    ],
    "lat": "45.32458",
    "lon": "-75.9044329126984",
    "display_name": "0, Tiffany Crescent, Beaverbrook, Kanata North, Kanata, Ottawa (city), K2K 1S2, Canada",
    "place_rank": 30,
    "category": "building",
    "type": "detached",
    "importance": 0.411,
    "address": {
      "house_number": "0",
      "road": "Tiffany Crescent",
      "neighbourhood": "Beaverbrook",
      "city_district": "Kanata North",
      "suburb": "Kanata",
      "county": "Ottawa (city)",
      "postcode": "K2K 1S2",
      "country": "Canada",
      "country_code": "ca"
    }
  }
]
```