### PR TITLE
Update installation documentation wrt memory usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@ Please make sure to add the following information:
  * the result you are getting
  * the expected result, preferably a link to the OSM object you want to find,
    otherwise an address that is as precise as possible
- 
- To get the link to the OSM object, you can try the following:
- 
+
+To get the link to the OSM object, you can try the following:
+
  * go to https://openstreetmap.org
  * zoom to the area of the map where you expect the result and
    zoom in as much as possible
@@ -26,7 +26,7 @@ Please make sure to add the following information:
  * find the object of interest in the list that appears on the left side
  * click on the object and report the URL back that the browser shows
 
-### When Reporting Problems with your Installation...
+### When Reporting Bugs...
 
 Please add the following information to your issue:
 
@@ -38,6 +38,9 @@ Please add the following information to your issue:
    if you run from the git repo, the output of `git rev-parse HEAD`)
  * (if applicable) exact command line of the command that was causing the issue
 
+Bug reports that do not include extensive information about your system,
+about the problem and about what you have been trying to debug the problem
+will be closed.
 
 ## Workflow for Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ https://nominatim.org/release-docs/develop/ .
 Installation
 ============
 
+**Nominatim is a complex piece of software and runs in a complex environment.
+Installing and running Nominatim is something for experienced system
+administrators only who can do some trouble-shooting themselves. We are sorry,
+but we can not provide installation support. We are all doing this in our free
+time and there is just so much of that time to go around. Do not open issues in
+our bug tracker if you need help. You can ask questions on the mailing list
+(see below) or on [help.openstreetmap.org](https://help.openstreetmap.org/).**
+
 The latest stable release can be downloaded from https://nominatim.org.
 There you can also find [installation instructions for the release](https://nominatim.org/release-docs/latest/admin/Installation).
 

--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -163,7 +163,7 @@ configuration as it may not be optimal for the import.
 In the first step of the import Nominatim uses osm2pgsql to load the OSM data
 into the PostgreSQL database. This step is very demanding in terms of RAM usage.
 osm2pgsql and PostgreSQL are running in parallel at this point. PostgreSQL
-blockes at least the part of RAM that has been configured with the
+blocks at least the part of RAM that has been configured with the
 `shared_buffers` parameter during [PostgreSQL tuning](Installation#PostgreSQL_tuning)
 and needs some memory on top of that. osm2pgsql needs at least 2GB of RAM for
 its internal data structures, potentially more when it has to process very large

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -55,15 +55,15 @@ For running continuous updates:
 ### Hardware
 
 A minimum of 2GB of RAM is required or installation will fail. For a full
-planet import 32GB of RAM or more are strongly recommended.
+planet import 64GB of RAM or more are strongly recommended. Do not report
+out of memory problems if you have less than 64GB RAM.
 
-For a full planet install you will need at least 700GB of hard disk space
+For a full planet install you will need at least 800GB of hard disk space
 (take into account that the OSM database is growing fast). SSD disks
 will help considerably to speed up import and queries.
 
-On a 6-core machine with 32GB RAM and SSDs the import of a full planet takes
-a bit more than 2 days. Without SSDs 7-8 days are more realistic.
-
+Even on a well configured machine the import of a full planet takes
+at least 2 days. Without SSDs 7-8 days are more realistic.
 
 ## Setup of the server
 
@@ -73,17 +73,21 @@ You might want to tune your PostgreSQL installation so that the later steps
 make best use of your hardware. You should tune the following parameters in
 your `postgresql.conf` file.
 
-    shared_buffers (2GB)
-    maintenance_work_mem (10GB)
-    work_mem (50MB)
-    effective_cache_size (24GB)
+    shared_buffers = 2GB
+    maintenance_work_mem = (10GB)
+    autovacuum_work_mem = 2GB
+    work_mem = (50MB)
+    effective_cache_size = (24GB)
     synchronous_commit = off
     checkpoint_segments = 100 # only for postgresql <= 9.4
+    max_wal_size = 1GB # postgresql > 9.4
     checkpoint_timeout = 10min
     checkpoint_completion_target = 0.9
 
 The numbers in brackets behind some parameters seem to work fine for
-32GB RAM machine. Adjust to your setup.
+64GB RAM machine. Adjust to your setup. A higher number for `max_wal_size`
+means that PostgreSQL needs to run checkpoints less often but it does require
+the additional space on your disk.
 
 For the initial import, you should also set:
 

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -29,10 +29,13 @@ class SetupFunctions
             warn('resetting threads to '.$this->iInstances);
         }
 
-        // Assume we can steal all the cache memory in the box (unless told otherwise)
         if (isset($aCMDResult['osm2pgsql-cache'])) {
             $this->iCacheMemory = $aCMDResult['osm2pgsql-cache'];
+        } elseif (!is_null(CONST_Osm2pgsql_Flatnode_File)) {
+            // When flatnode files are enabled then disable cache per default.
+            $this->iCacheMemory = 0;
         } else {
+            // Otherwise: Assume we can steal all the cache memory in the box.
             $this->iCacheMemory = getCacheMemoryMB();
         }
 


### PR DESCRIPTION
* Increases minimum required RAM for planet installations to 64GB. Those who know what they are doing should still be able to import with less but they have been warned.
* Add a section with background info about time and memory usage, so people can better understand what is going on with their import.
* By default disable node cache in osm2pgsql when a flatnode file is used. This should decrease the probability that the installation process runs into out-of-memory situations.

The PR also adds a clear warning to the README that the github issue tracker is the wrong place to ask for installation support. The increase in support tickets here is simply taking too much time off the maintainers that should be better spent improving the software. This has to stop. I suggest, we create an issue template that clearly states the minimum information a ticket must contain (similar to what is already in the CONTRIBUTING file) and then close any tickets immediately that are not up to those standards.