### PR TITLE
Centos Vagrant: Add CLANG=true to make

### DIFF
--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -172,7 +172,7 @@ fi                                 #DOCS:
     mkdir build
     cd build
     cmake $USERHOME/Nominatim
-    make
+    make CLANG=true
 
 #
 # Adding SELinux Security Settings


### PR DESCRIPTION
Apparently this fixes https://github.com/openstreetmap/Nominatim/issues/1611

Only relevant reference I found is https://github.com/powa-team/pg_stat_kcache/issues/15#issuecomment-422683516 

I recreated the vagrant VM and saw no difference (no new warnings or such).

