### PR TITLE
Vagrant install instructions for CentOS 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,18 @@ Vagrant.configure("2") do |config|
       sub.vm.synced_folder ".", "/vagrant", disabled: true
   end
 
+  config.vm.define "centos8" do |sub|
+      sub.vm.box = "generic/centos8"
+      sub.vm.provision :shell do |s|
+        s.path = "vagrant/Install-on-Centos-8.sh"
+        s.privileged = false
+        s.args = "yes"
+      end
+      sub.vm.synced_folder ".", "/home/vagrant/Nominatim", disabled: true
+      sub.vm.synced_folder ".", "/vagrant", disabled: true
+  end
+
+
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
     vb.memory = 2048

--- a/utils/update.php
+++ b/utils/update.php
@@ -82,6 +82,12 @@ if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {
 }
 
 $sIndexCmd = CONST_BasePath.'/nominatim/nominatim.py';
+if (!$aResult['quiet']) {
+    $sIndexCmd .= ' -v';
+}
+if ($aResult['verbose']) {
+    $sIndexCmd .= ' -v';
+}
 
 if ($aResult['init-updates']) {
     // sanity check that the replication URL is correct

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# *Note:* these installation instructions are also available in executable
+#         form for use with vagrant under `vagrant/Install-on-Centos-7.sh`.
+#
+# Installing the Required Software
+# ================================
+#
+# These instructions expect that you have a freshly installed CentOS version 7.
+# Make sure all packages are up-to-date by running:
+#
+    sudo yum update -y
+
+# The standard CentOS repositories don't contain all the required packages,
+# you need to enable the EPEL repository as well. To enable it on CentOS,
+# install the epel-release RPM by running:
+
+    sudo yum install -y epel-release
+
+# More repositories for postgresql 11 (CentOS default 'postgresql' is 9.2), postgis
+# and llvm-toolset (https://github.com/theory/pg-semver/issues/35)
+
+    # sudo yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    # sudo yum install -y centos-release-scl-rh
+    sudo dnf install -y redhat-rpm-config
+
+# Now you can install all packages needed for Nominatim:
+
+#DOCS:    :::sh
+    sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    sudo dnf -qy module disable postgresql
+    sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    sudo dnf --enablerepo=PowerTools install -y postgresql12-server postgresql12-contrib postgresql12-devel postgis30_12
+
+
+sudo dnf install -y llvm-toolset ccache
+
+    sudo yum install -y wget git cmake make gcc gcc-c++ libtool policycoreutils-python-utils \
+                        php-pgsql php php-intl php-json libpqxx-devel \
+                        proj52-epsg bzip2-devel proj-devel boost-devel \
+                        expat-devel zlib-devel
+
+# postgresql11-server-debuginfo postgresql11-contrib-debuginfo postgresql-devel \
+#                         postgis25_11 postgis25_11-utils \
+
+#                         devtoolset-8 llvm-toolset-8 \
+
+# If you want to run the test suite, you need to install the following
+# additional packages:
+
+#DOCS:    :::sh
+    sudo yum install -y python36 python3-pip python3-setuptools python36-devel
+     # \
+     #                    php-phpunit-PHPUnit
+    pip3 install --user behave nose pytidylib psycopg2
+
+    composer global require "squizlabs/php_codesniffer=*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+
+#
+# System Configuration
+# ====================
+#
+# The following steps are meant to configure a fresh CentOS installation
+# for use with Nominatim. You may skip some of the steps if you have your
+# OS already configured.
+#
+# Creating Dedicated User Accounts
+# --------------------------------
+#
+# Nominatim will run as a global service on your machine. It is therefore
+# best to install it under its own separate user account. In the following
+# we assume this user is called nominatim and the installation will be in
+# /srv/nominatim. To create the user and directory run:
+#
+sudo mkdir -p /srv/nominatim       #DOCS:    sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
+sudo chown vagrant /srv/nominatim  #DOCS:
+#
+# You may find a more suitable location if you wish.
+#
+# To be able to copy and paste instructions from this manual, export
+# user name and home directory now like this:
+#
+    export USERNAME=vagrant        #DOCS:    export USERNAME=nominatim
+    export USERHOME=/srv/nominatim
+#
+# **Never, ever run the installation as a root user.** You have been warned.
+#
+# Make sure that system servers can read from the home directory:
+
+    chmod a+x $USERHOME
+
+# Setting up PostgreSQL
+# ---------------------
+#
+# CentOS does not automatically create a database cluster. Therefore, start
+# with initializing the database, then enable the server to start at boot:
+
+    echo 'PATH=$PATH:/usr/pgsql-12/bin' > .bash_profile
+    source .bash_profile
+
+    sudo /usr/pgsql-12/bin/postgresql-12-setup initdb
+    sudo systemctl enable postgresql-12
+
+#
+# Next tune the postgresql configuration, which is located in 
+# `/var/lib/pgsql/data/postgresql.conf`. See section *Postgres Tuning* in
+# [the installation page](../admin/Installation.md#postgresql-tuning)
+# for the parameters to change.
+#
+# Now start the postgresql service after updating this config file.
+
+    sudo systemctl restart postgresql-12
+
+#
+# Finally, we need to add two postgres users: one for the user that does
+# the import and another for the webserver which should access the database
+# only for reading:
+#
+
+    sudo -u postgres createuser -s $USERNAME
+    sudo -u postgres createuser apache
+
+#
+# Setting up the Apache Webserver
+# -------------------------------
+#
+# You need to create an alias to the website directory in your apache
+# configuration. Add a separate nominatim configuration to your webserver:
+
+#DOCS:```sh
+sudo tee /etc/httpd/conf.d/nominatim.conf << EOFAPACHECONF
+<Directory "$USERHOME/build/website">
+  Options FollowSymLinks MultiViews
+  AddType text/html   .php
+  DirectoryIndex search.php
+  Require all granted
+</Directory>
+
+Alias /nominatim $USERHOME/build/website
+EOFAPACHECONF
+#DOCS:```
+
+sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
+
+#
+# Then reload apache
+#
+
+    sudo systemctl enable httpd
+    sudo systemctl restart httpd
+
+
+#
+# Installing Nominatim
+# ====================
+#
+# Building and Configuration
+# --------------------------
+#
+# Get the source code from Github and change into the source directory
+#
+if [ "x$1" == "xyes" ]; then  #DOCS:    :::sh
+    cd $USERHOME
+    git clone --recursive --depth 10 git://github.com/openstreetmap/Nominatim.git
+    cd Nominatim
+else                               #DOCS:
+    cd $USERHOME/Nominatim         #DOCS:
+fi                                 #DOCS:
+
+# When installing the latest source from github, you also need to
+# download the country grid:
+
+if [ ! -f data/country_osm_grid.sql.gz ]; then       #DOCS:    :::sh
+    wget --no-verbose -O data/country_osm_grid.sql.gz https://www.nominatim.org/data/country_grid.sql.gz
+fi                                 #DOCS:
+
+# The code must be built in a separate directory. Create this directory,
+# then configure and build Nominatim in there:
+
+#DOCS:    :::sh
+    cd $USERHOME
+    mkdir build
+    cd build
+    PostgreSQL_ROOT=/usr/pgsql-12 cmake $USERHOME/Nominatim
+    make
+
+#
+# Adding SELinux Security Settings
+# --------------------------------
+#
+# It is a good idea to leave SELinux enabled and enforcing, particularly
+# with a web server accessible from the Internet. At a minimum the
+# following SELinux labeling should be done for Nominatim:
+
+    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/Nominatim/(website|lib|settings)(/.*)?"
+    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/build/(website|lib|settings)(/.*)?"
+    sudo semanage fcontext -a -t lib_t "$USERHOME/build/module/nominatim.so"
+    sudo restorecon -R -v $USERHOME/Nominatim
+    sudo restorecon -R -v $USERHOME/build
+
+
+# You need to create a minimal configuration file that tells nominatim
+# the name of your webserver user and the URL of the website:
+
+#DOCS:```sh
+tee settings/local.php << EOF
+<?php
+ @define('CONST_Database_Web_User', 'apache');
+ @define('CONST_Website_BaseURL', '/nominatim/');
+EOF
+#DOCS:```
+
+
+# Nominatim is now ready to use. Continue with
+# [importing a database from OSM data](../admin/Import-and-Update.md).

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -17,8 +17,8 @@
 
     sudo dnf install -y epel-release redhat-rpm-config
 
-# More repositories for postgresql 12 and postgis (CentOS default 'postgresql'
-# is either 9.6 or 10)
+# EPEL contains Postgres 9.6 and 10, but not PostGIS. Postgres 9.4+/10/11/12
+# and PostGIS 2.4/2.5/3.0 are availble from postgresql.org
 
     sudo dnf -qy module disable postgresql
     sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
@@ -26,18 +26,17 @@
 # Now you can install all packages needed for Nominatim:
 
 #DOCS:    :::sh
-    sudo dnf --enablerepo=PowerTools install -y postgresql12-server \
-                        postgresql12-contrib postgresql12-devel postgis30_12 \
+    sudo dnf --enablerepo=PowerTools install -y postgresql10-server \
+                        postgresql10-contrib postgresql10-devel postgis25_10 \
                         wget git cmake make gcc gcc-c++ libtool policycoreutils-python-utils \
-                        llvm-toolset ccache \
-                        php-pgsql php php-intl php-json libpqxx-devel \
+                        llvm-toolset ccache clang-tools-extra \
+                        php-pgsql php php-intl php-json libpq-devel \
                         proj52-epsg bzip2-devel proj-devel boost-devel \
                         expat-devel zlib-devel
-                        
 
     # make sure pg_config gets found
-    echo 'PATH=$PATH:/usr/pgsql-12/bin' > ~/.bash_profile
-    source ~/.bash_profile
+    # echo 'PATH=$PATH:/usr/pgsql-10/bin' >> ~/.bash_profile
+    # source ~/.bash_profile
 
 # If you want to run the test suite, you need to install the following
 # additional packages:
@@ -51,8 +50,8 @@
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 
-    composer global require "phpunit/phpunit ^7"
-    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+    composer global require "phpunit/phpuni ^7"
+    sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
 
 #
 # System Configuration
@@ -94,8 +93,8 @@ sudo chown vagrant /srv/nominatim  #DOCS:
 # with initializing the database, then enable the server to start at boot:
 
 
-    sudo /usr/pgsql-12/bin/postgresql-12-setup initdb
-    sudo systemctl enable postgresql-12
+    sudo /usr/pgsql-10/bin/postgresql-10-setup initdb
+    sudo systemctl enable postgresql-10
 
 #
 # Next tune the postgresql configuration, which is located in 
@@ -105,7 +104,7 @@ sudo chown vagrant /srv/nominatim  #DOCS:
 #
 # Now start the postgresql service after updating this config file.
 
-    sudo systemctl restart postgresql-12
+    sudo systemctl restart postgresql-10
 
 #
 # Finally, we need to add two postgres users: one for the user that does
@@ -177,7 +176,7 @@ fi                                 #DOCS:
     cd $USERHOME
     mkdir build
     cd build
-    PostgreSQL_ROOT=/usr/pgsql-12 cmake $USERHOME/Nominatim
+    PostgreSQL_ROOT=/usr/pgsql-10 cmake $USERHOME/Nominatim
     make
 
 #


### PR DESCRIPTION
Postgresql 12, PostGIS 3, PHP 7.2, Python 3.6

Imported Monaco and website returned results.

`dnf` replaces `yum` in RedHat Enterprise Linux 8 / Fedora 22 / CentOS 8. https://en.wikipedia.org/wiki/DNF_(software)

Postgresql gets installed into `/usr/pgsql-12/`, that's not too different from our CentOS 7 instructions (`/usr/pgsql-11/`) but I had to set paths explicitly for Nominatim CMake and `psycopg2` to find the lib and include paths.

Two lines require PHP `composer` to be installed and thus fail. That's the same in our other Ubuntu/CentOS instructions. Few developers want to run tests and for those who do it's easy to install `composer`. There's no system packages for `composer`, the recommendation is downloading a file and piping into the shell.