### PR TITLE
Vagrant setup for CentOS 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,18 @@ Vagrant.configure("2") do |config|
       sub.vm.synced_folder ".", "/vagrant", disabled: true
   end
 
+  config.vm.define "centos8" do |sub|
+      sub.vm.box = "generic/centos8"
+      sub.vm.provision :shell do |s|
+        s.path = "vagrant/Install-on-Centos-8.sh"
+        s.privileged = false
+        s.args = "yes"
+      end
+      sub.vm.synced_folder ".", "/home/vagrant/Nominatim", disabled: true
+      sub.vm.synced_folder ".", "/vagrant", disabled: true
+  end
+
+
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
     vb.memory = 2048


### PR DESCRIPTION
```
$ psql --version
psql (PostgreSQL) 10.11

$ psql -c 'select postgis_lib_version()' nominatim
2.5.3

$ php --version
PHP 7.2.11

$ python3 --version
Python 3.6.8
```

Imported Monaco and website returned results.

`dnf` replaces `yum` in RedHat Enterprise Linux 8 / Fedora 22 / CentOS 8. https://en.wikipedia.org/wiki/DNF_(software)

Two lines require PHP composer to be installed and thus fail. That's the same in our other Ubuntu/CentOS instructions. Few developers want to run tests and for those who do it's easy to install composer. There's no system packages for composer, the recommendation is downloading a file and piping into the shell.