### PR TITLE
CentOS7: update from PHP 5.4 to 7.2, add psycopg2

### DIFF
--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -23,6 +23,12 @@
     sudo yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     sudo yum install -y centos-release-scl-rh
 
+# More repositories for PHP 7 (default is PHP 5.4)
+
+    sudo yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+    sudo yum-config-manager --enable remi-php72
+    sudo yum update -y
+
 # Now you can install all packages needed for Nominatim:
 
 #DOCS:    :::sh
@@ -33,22 +39,27 @@
                         devtoolset-7 llvm-toolset-7 \
                         php-pgsql php php-intl libpqxx-devel \
                         proj-epsg bzip2-devel proj-devel boost-devel \
+                        python3-pip python3-setuptools python3-devel \
                         expat-devel zlib-devel
 
     # make sure pg_config gets found
-    echo 'PATH=/usr/pgsql-11/bin/$PATH' >> ~/.bash_profile
+    echo 'PATH=/usr/pgsql-11/bin/:$PATH' >> ~/.bash_profile
     source ~/.bash_profile
+
+    pip3 install --user psycopg2 pytidylib
 
 # If you want to run the test suite, you need to install the following
 # additional packages:
 
 #DOCS:    :::sh
-    sudo yum install -y python34-pip python34-setuptools python34-devel \
-                        php-phpunit-PHPUnit
-    pip3 install --user behave nose pytidylib psycopg2
+    sudo yum install -y php-dom php-mbstring
+    pip3 install --user behave nose
 
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+
+    composer global require "phpunit/phpunit=7.*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -32,20 +32,21 @@
                         llvm-toolset ccache clang-tools-extra \
                         php-pgsql php php-intl php-json libpq-devel \
                         proj52-epsg bzip2-devel proj-devel boost-devel \
+                        python3-pip python3-setuptools python3-devel \
                         expat-devel zlib-devel
 
     # make sure pg_config gets found
     echo 'PATH=/usr/pgsql-10/bin:$PATH' >> ~/.bash_profile
     source ~/.bash_profile
 
+    pip3 install --user psycopg2 pytidylib
+
 # If you want to run the test suite, you need to install the following
 # additional packages:
 
 #DOCS:    :::sh
-    sudo dnf install -y python36 python3-pip python3-setuptools python36-devel \
-                        php-dom php-mbstring
-
-    pip3 install --user behave nose pytidylib psycopg2
+    sudo dnf install -y php-dom php-mbstring
+    pip3 install --user behave nose
 
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/


### PR DESCRIPTION
- fix bug in setting `$PATH` environment variable I introduced in my last PR
- CentOS 7 defaults to PHP 5.4, update to 7.2
- CentOS 7 default to phpunit 4.x, we need at least 7.x to run the unit tests
- requiring `python` seems to be enough and leads to 3.6, no need to require `python34`
- `psycopg2` is now a requirement