### PR TITLE
Vagrant Ubuntu: psycopg2 is required

### DIFF
--- a/vagrant/Install-on-Ubuntu-16.sh
+++ b/vagrant/Install-on-Ubuntu-16.sh
@@ -30,18 +30,24 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             postgresql-server-dev-9.5 postgresql-9.5-postgis-2.2 \
                             postgresql-contrib-9.5 \
                             apache2 php php-pgsql libapache2-mod-php \
-                            php-intl git
+                            php-intl python3-setuptools python3-dev python3-pip \
+                            python3-tidylib git
+
+    # python3-psycopg2 apt package is too old (2.6), we want at least 2.7
+    pip3 install --user psycopg2
 
 # If you want to run the test suite, you need to install the following
 # additional packages:
 
-    sudo apt-get install -y python3-setuptools python3-dev python3-pip \
-                            python3-psycopg2 python3-tidylib phpunit php-cgi
+    sudo apt-get install -y php-cgi php-mbstring
 
     pip3 install --user behave nose
 
     composer global require "squizlabs/php_codesniffer=*"
     sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+
+    composer global require "phpunit/phpunit=6.*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/Install-on-Ubuntu-18-nginx.sh
+++ b/vagrant/Install-on-Ubuntu-18-nginx.sh
@@ -23,7 +23,8 @@ export DEBIAN_FRONTEND=noninteractive
                             postgresql-server-dev-10 postgresql-10-postgis-2.4 \
                             postgresql-contrib-10 \
                             nginx php-fpm php php-pgsql \
-                            php-intl git
+                            php-intl python3-setuptools python3-dev python3-pip \
+                            python3-psycopg2 python3-tidylib git
 
     export USERNAME=vagrant
     export USERHOME=/home/vagrant

--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -30,13 +30,13 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             postgresql-server-dev-10 postgresql-10-postgis-2.4 \
                             postgresql-contrib-10 postgresql-10-postgis-scripts \
                             apache2 php php-pgsql libapache2-mod-php \
-                            php-intl git
+                            php-intl python3-setuptools python3-dev python3-pip \
+                            python3-psycopg2 python3-tidylib git
 
 # If you want to run the test suite, you need to install the following
 # additional packages:
 
-    sudo apt-get install -y python3-setuptools python3-dev python3-pip \
-                            python3-psycopg2 python3-tidylib phpunit php-cgi
+    sudo apt-get install -y phpunit php-cgi
 
     pip3 install --user behave nose
 


### PR DESCRIPTION
- `psycopg2` is now a requirement, no longer optional
- Ubuntu16 defaults to PHP 7.0, that's too old for phpunit 7, but 6 seems to still work
