### PR TITLE
Enable Permalinks to dtails for tiger and interpolation

### DIFF
--- a/lib/output.php
+++ b/lib/output.php
@@ -48,5 +48,5 @@ function detailsPermaLink($aFeature, $sRefText = false)
         $sLabel = $sRefText ? $sRefText : $sOSMType.' '.$aFeature['osm_id'];
         return '<a href="details.php?osmtype='.$aFeature['osm_type'].'&osmid='.$aFeature['osm_id'].'&class='.$aFeature['class'].'">'.$sLabel.'</a>';
     }
-    return '';
+    return detailsLink($aFeature, $sRefText);
 }

--- a/lib/output.php
+++ b/lib/output.php
@@ -33,20 +33,39 @@ function wikipediaLink($aFeature)
     return '';
 }
 
-function detailsLink($aFeature, $sTitle = false)
+function detailsLink($aFeature, $sTitle = false, $sExtraProperties = false)
 {
     if (!$aFeature['place_id']) return '';
 
-    return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
+    $sHtml = '<a ';
+    if ($sExtraProperties) {
+        $sHtml .= $sExtraProperties.' ';
+    }
+
+    $sHtml .= 'href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
+
+    return $sHtml;
 }
 
-function detailsPermaLink($aFeature, $sRefText = false)
+function detailsPermaLink($aFeature, $sRefText = false, $sExtraProperties = false)
 {
     $sOSMType = formatOSMType($aFeature['osm_type'], false);
 
     if ($sOSMType) {
-        $sLabel = $sRefText ? $sRefText : $sOSMType.' '.$aFeature['osm_id'];
-        return '<a href="details.php?osmtype='.$aFeature['osm_type'].'&osmid='.$aFeature['osm_id'].'&class='.$aFeature['class'].'">'.$sLabel.'</a>';
+        $sHtml = '<a ';
+        if ($sExtraProperties) {
+            $sHtml .= $sExtraProperties.' ';
+        }
+        $sHtml .= 'href="details.php?osmtype='.$aFeature['osm_type']
+                  .'&osmid='.$aFeature['osm_id'].'&class='.$aFeature['class'].'">';
+
+        if ($sRefText) {
+            $sHtml .= $sRefText.'</a>';
+        } else {
+            $sHtml .= $sOSMType.' '.$aFeature['osm_id'].'</a>';
+        }
+
+        return $sHtml;
     }
-    return detailsLink($aFeature, $sRefText);
+    return detailsLink($aFeature, $sRefText, $sExtraProperties);
 }

--- a/lib/output.php
+++ b/lib/output.php
@@ -12,6 +12,8 @@ function formatOSMType($sType, $bIncludeExternal = true)
     if ($sType == 'T') return 'way';
     if ($sType == 'I') return 'way';
 
+    // not handled: P, L
+
     return '';
 }
 

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -85,7 +85,7 @@
             else
                 echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['type'])).')</span>';
             echo '<p>'.$aResult['lat'].','.$aResult['lon'].'</p>';
-            echo ' <a class="btn btn-default btn-xs details" href="details.php?osmtype='.$aResult['osm_type'].'&osmid='.$aResult['osm_id'].'&class='.$aResult['class'].'">details</a>';
+            echo detailsPermaLink($aResult, 'details', 'class="btn btn-default btn-xs details"');
             echo '</div>';
         ?>
         </div>

--- a/lib/template/search-html.php
+++ b/lib/template/search-html.php
@@ -53,7 +53,7 @@
                     echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['class'])).')</span>';
                 else
                     echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['type'])).')</span>';
-                echo ' <a class="btn btn-default btn-xs details" href="details.php?osmtype='.$aResult['osm_type'].'&osmid='.$aResult['osm_id'].'&class='.$aResult['class'].'">details</a>';
+                echo detailsPermaLink($aResult, 'details', 'class="btn btn-default btn-xs details"');
                 echo '</div>';
                 $i = $i+1;
             }

--- a/test/php/Nominatim/OutputTest.php
+++ b/test/php/Nominatim/OutputTest.php
@@ -51,6 +51,25 @@ class OutputTest extends \PHPUnit\Framework\TestCase
                 );
     }
 
+    public function testDetailsPermaLinkWithExtraPropertiesNode()
+    {
+        $aFeature = array('osm_type' => 'N', 'osm_id'=> 2, 'class' => 'amenity');
+        $this->assertSame(
+                detailsPermaLink($aFeature, 'something', 'class="xtype"'),
+                '<a class="xtype" href="details.php?osmtype=N&osmid=2&class=amenity">something</a>'
+                );
+    }
+
+    public function testDetailsPermaLinkWithExtraPropertiesTiger()
+    {
+        $aFeature = array('osm_type' => 'T', 'osm_id'=> 5, 'place_id' => 46);
+        $this->assertSame(
+                detailsPermaLink($aFeature, 'something', 'class="xtype"'),
+                '<a class="xtype" href="details.php?place_id=46">something</a>'
+                );
+    }
+
+
 
 
 

--- a/test/php/Nominatim/OutputTest.php
+++ b/test/php/Nominatim/OutputTest.php
@@ -10,67 +10,62 @@ class OutputTest extends \PHPUnit\Framework\TestCase
     {
         $aFeature = array('osm_type' => 'N', 'osm_id'=> 38274, 'class' => 'place');
         $this->assertSame(
-                detailsPermaLink($aFeature),
-                '<a href="details.php?osmtype=N&osmid=38274&class=place">node 38274</a>'
-                );
+            detailsPermaLink($aFeature),
+            '<a href="details.php?osmtype=N&osmid=38274&class=place">node 38274</a>'
+        );
     }
 
     public function testDetailsPermaLinkWay()
     {
         $aFeature = array('osm_type' => 'W', 'osm_id'=> 65, 'class' => 'highway');
         $this->assertSame(
-                detailsPermaLink($aFeature),
-                '<a href="details.php?osmtype=W&osmid=65&class=highway">way 65</a>'
-                );
+            detailsPermaLink($aFeature),
+            '<a href="details.php?osmtype=W&osmid=65&class=highway">way 65</a>'
+        );
     }
 
     public function testDetailsPermaLinkRelation()
     {
         $aFeature = array('osm_type' => 'R', 'osm_id'=> 9908, 'class' => 'waterway');
         $this->assertSame(
-                detailsPermaLink($aFeature),
-                '<a href="details.php?osmtype=R&osmid=9908&class=waterway">relation 9908</a>'
-                );
+            detailsPermaLink($aFeature),
+            '<a href="details.php?osmtype=R&osmid=9908&class=waterway">relation 9908</a>'
+        );
     }
 
     public function testDetailsPermaLinkTiger()
     {
         $aFeature = array('osm_type' => 'T', 'osm_id'=> 2, 'place_id' => 334);
         $this->assertSame(
-                detailsPermaLink($aFeature, 'foo'),
-                '<a href="details.php?place_id=334">foo</a>'
-                );
+            detailsPermaLink($aFeature, 'foo'),
+            '<a href="details.php?place_id=334">foo</a>'
+        );
     }
 
     public function testDetailsPermaLinkInterpolation()
     {
         $aFeature = array('osm_type' => 'I', 'osm_id'=> 400, 'place_id' => 3);
         $this->assertSame(
-                detailsPermaLink($aFeature, 'foo'),
-                '<a href="details.php?place_id=3">foo</a>'
-                );
+            detailsPermaLink($aFeature, 'foo'),
+            '<a href="details.php?place_id=3">foo</a>'
+        );
     }
 
     public function testDetailsPermaLinkWithExtraPropertiesNode()
     {
         $aFeature = array('osm_type' => 'N', 'osm_id'=> 2, 'class' => 'amenity');
         $this->assertSame(
-                detailsPermaLink($aFeature, 'something', 'class="xtype"'),
-                '<a class="xtype" href="details.php?osmtype=N&osmid=2&class=amenity">something</a>'
-                );
+            detailsPermaLink($aFeature, 'something', 'class="xtype"'),
+            '<a class="xtype" href="details.php?osmtype=N&osmid=2&class=amenity">something</a>'
+        );
     }
 
     public function testDetailsPermaLinkWithExtraPropertiesTiger()
     {
         $aFeature = array('osm_type' => 'T', 'osm_id'=> 5, 'place_id' => 46);
         $this->assertSame(
-                detailsPermaLink($aFeature, 'something', 'class="xtype"'),
-                '<a class="xtype" href="details.php?place_id=46">something</a>'
-                );
+            detailsPermaLink($aFeature, 'something', 'class="xtype"'),
+            '<a class="xtype" href="details.php?place_id=46">something</a>'
+        );
     }
-
-
-
-
-
 }

--- a/test/php/Nominatim/OutputTest.php
+++ b/test/php/Nominatim/OutputTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Nominatim;
+
+require_once(CONST_BasePath.'/lib/output.php');
+
+class OutputTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDetailsPermaLinkNode()
+    {
+        $aFeature = array('osm_type' => 'N', 'osm_id'=> 38274, 'class' => 'place');
+        $this->assertSame(
+                detailsPermaLink($aFeature),
+                '<a href="details.php?osmtype=N&osmid=38274&class=place">node 38274</a>'
+                );
+    }
+
+    public function testDetailsPermaLinkWay()
+    {
+        $aFeature = array('osm_type' => 'W', 'osm_id'=> 65, 'class' => 'highway');
+        $this->assertSame(
+                detailsPermaLink($aFeature),
+                '<a href="details.php?osmtype=W&osmid=65&class=highway">way 65</a>'
+                );
+    }
+
+    public function testDetailsPermaLinkRelation()
+    {
+        $aFeature = array('osm_type' => 'R', 'osm_id'=> 9908, 'class' => 'waterway');
+        $this->assertSame(
+                detailsPermaLink($aFeature),
+                '<a href="details.php?osmtype=R&osmid=9908&class=waterway">relation 9908</a>'
+                );
+    }
+
+    public function testDetailsPermaLinkTiger()
+    {
+        $aFeature = array('osm_type' => 'T', 'osm_id'=> 2, 'place_id' => 334);
+        $this->assertSame(
+                detailsPermaLink($aFeature, 'foo'),
+                '<a href="details.php?place_id=334">foo</a>'
+                );
+    }
+
+    public function testDetailsPermaLinkInterpolation()
+    {
+        $aFeature = array('osm_type' => 'I', 'osm_id'=> 400, 'place_id' => 3);
+        $this->assertSame(
+                detailsPermaLink($aFeature, 'foo'),
+                '<a href="details.php?place_id=3">foo</a>'
+                );
+    }
+
+
+
+
+}

--- a/website/details.php
+++ b/website/details.php
@@ -44,6 +44,16 @@ if ($sOsmType && $iOsmId > 0) {
     $sSQL .= ' ORDER BY class ASC';
     $sPlaceId = $oDB->getOne($sSQL, array(':type' => $sOsmType, ':id' => $iOsmId));
 
+
+    // Nothing? Maybe it's an interpolation.
+    // XXX Simply returns the first parent street it finds. It should
+    //     get a house number and get the right interpolation.
+    if (!$sPlaceId && $sOsmType == 'W' && (!$sClass || $sClass == 'place')) {
+        $sSQL = 'SELECT place_id FROM location_property_osmline'
+                .' WHERE osm_id = :id LIMIT 1';
+        $sPlaceId = $oDB->getOne($sSQL, array(':id' => $iOsmId));
+    }
+
     // Be nice about our error messages for broken geometry
 
     if (!$sPlaceId) {


### PR DESCRIPTION
This fixes permalinking for Tiger and interpolation objects. Tiger object simply use the old place_id link to get the right details page. For interpolations the details page looks in the location_property_osmline table when details for an OSM way are requested.

Also adds unit tests for detailsPermaLink() and uses the function in the address and search HTML views as well.