### PR TITLE
FAQ entry about psycopg2 error message

### DIFF
--- a/docs/admin/Faq.md
+++ b/docs/admin/Faq.md
@@ -179,6 +179,11 @@ That's fine. For each import the flatnodes file get overwritten.
 See [https://help.openstreetmap.org/questions/52419/nominatim-flatnode-storage]()
 for more information.
 
+### psycopg2 reports "invalid connection option "async_""
+
+Make sure you use at least psycopg2 version 2.7. Try upgrading using
+`pip3 install --user psycopg2`
+
 
 ## Running your own instance
 


### PR DESCRIPTION
I saw this error on Ubuntu 16 when running indexing. The stacktrace makes it looks like `nominatim.py` sets something wrong, but the better solution is upgrading the library. Background: Python 3.7 will introduce a `async` reversed keyword and the psycopg2 authors renamed the options appending an underscore.