### PR TITLE
wikipedia: wget didnt download, skip index generation

### DIFF
--- a/data-sources/wikipedia-wikidata/import_wikidata.sh
+++ b/data-sources/wikipedia-wikidata/import_wikidata.sh
@@ -10,7 +10,7 @@ mysql2pgsqlcmd() {
 
 download() {
      echo "Downloading $1"
-     wget --quiet --no-clobber --tries 3
+     wget --quiet --no-clobber --tries 3 "$1"
 }
 
 # languages to process (refer to List of Wikipedias here: https://en.wikipedia.org/wiki/List_of_Wikipedias)


### PR DESCRIPTION
* the `wget` command was missing the URL
* less verbose output
* almost all queries are full table scans, by moving table creation into the script we can skip index creation (requires less disc space and faster import). For the enpage table alone that's 150GB of less indices.
* merged the `ALTER TABLE` statment of `..pagelinkcount` into the create statement
* make sure `..pagelinkcount` for all languages are created before being used later is an inner loop

Most time is still spend importing. Downloading 1h, import 14h

I experimented with check constrains on import. With `..pages` the savings was up to 50% but I couldn't get it working with the other tables, they ended up empty.

It's worth testing to import and process in MySQL and skip `mysql2pgsql.perl`.

I haven't found a good solution to process language by language (yet).