### PR TITLE
Fix a couple of issues with the new Python nominatim script

### DIFF
--- a/nominatim/nominatim.py
+++ b/nominatim/nominatim.py
@@ -35,9 +35,14 @@ import select
 log = logging.getLogger()
 
 def make_connection(options, asynchronous=False):
-    return psycopg2.connect(dbname=options.dbname, user=options.user,
-                            password=options.password, host=options.host,
-                            port=options.port, async_=asynchronous)
+    params = {'dbname' : options.dbname,
+              'user' : options.user,
+              'password' : options.password,
+              'host' : options.host,
+              'port' : options.port,
+              'async' : asynchronous}
+
+    return psycopg2.connect(**params)
 
 
 class RankRunner(object):

--- a/vagrant/Install-on-Ubuntu-16.sh
+++ b/vagrant/Install-on-Ubuntu-16.sh
@@ -31,10 +31,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             postgresql-contrib-9.5 \
                             apache2 php php-pgsql libapache2-mod-php \
                             php-intl python3-setuptools python3-dev python3-pip \
-                            python3-tidylib git
-
-    # python3-psycopg2 apt package is too old (2.6), we want at least 2.7
-    pip3 install --user psycopg2
+                            python3-tidylib python3-psycopg2 git
 
 # If you want to run the test suite, you need to install the following
 # additional packages:


### PR DESCRIPTION
* regularly close and reopen connections to avoid memory leaks in Postgres becoming and issue
* also catch deadlocks on the final wait()
* also catch `psycopg2.errors.DeadlockDetected` (since psycopg 2.8)
* use async parameter for connect() (async_ only available since psycopg 2.7)