### PR TITLE
Clean up intermediate tables earlier with --drop

### DIFF
--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -8,7 +8,6 @@ CREATE INDEX CONCURRENTLY idx_place_addressline_address_place_id on place_addres
 DROP INDEX CONCURRENTLY IF EXISTS idx_placex_rank_search;
 CREATE INDEX CONCURRENTLY idx_placex_rank_search ON placex USING BTREE (rank_search) {ts:search-index};
 CREATE INDEX CONCURRENTLY idx_placex_rank_address ON placex USING BTREE (rank_address) {ts:search-index};
-CREATE INDEX CONCURRENTLY idx_placex_pendingsector ON placex USING BTREE (rank_search,geometry_sector) {ts:address-index} where indexed_status > 0;
 CREATE INDEX CONCURRENTLY idx_placex_parent_place_id ON placex USING BTREE (parent_place_id) {ts:search-index} where parent_place_id IS NOT NULL;
 
 CREATE INDEX CONCURRENTLY idx_placex_geometry_reverse_lookupPoint
@@ -29,14 +28,8 @@ CREATE INDEX CONCURRENTLY idx_placex_geometry_reverse_placeNode
 
 GRANT SELECT ON table country_osm_grid to "{www-user}";
 
-CREATE INDEX CONCURRENTLY idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
-
 CREATE INDEX CONCURRENTLY idx_osmline_parent_place_id ON location_property_osmline USING BTREE (parent_place_id) {ts:search-index};
 CREATE INDEX CONCURRENTLY idx_osmline_parent_osm_id ON location_property_osmline USING BTREE (osm_id) {ts:search-index};
-
-DROP INDEX CONCURRENTLY IF EXISTS place_id_idx;
-CREATE UNIQUE INDEX CONCURRENTLY idx_place_osm_unique on place using btree(osm_id,osm_type,class,type) {ts:address-index};
-
 
 CREATE UNIQUE INDEX CONCURRENTLY idx_postcode_id ON location_postcode USING BTREE (place_id) {ts:search-index};
 CREATE INDEX CONCURRENTLY idx_postcode_postcode ON location_postcode USING BTREE (postcode) {ts:search-index};

--- a/sql/indices_updates.src.sql
+++ b/sql/indices_updates.src.sql
@@ -1,0 +1,9 @@
+-- Indices used only during search and update.
+-- These indices are created only after the indexing process is done.
+
+CREATE INDEX CONCURRENTLY idx_placex_pendingsector ON placex USING BTREE (rank_search,geometry_sector) {ts:address-index} where indexed_status > 0;
+
+CREATE INDEX CONCURRENTLY idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
+
+DROP INDEX CONCURRENTLY IF EXISTS place_id_idx;
+CREATE UNIQUE INDEX CONCURRENTLY idx_place_osm_unique on place using btree(osm_id,osm_type,class) {ts:address-index};

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -29,8 +29,8 @@ Feature: Creation of search terms
         And the places
          | osm | class   | type        | name     | geometry |
          | N1  | place   | state       | new york | 80 80 |
-         | N1  | place   | city        | bonn     | 81 81 |
-         | N1  | place   | suburb      | smalltown| 80 81 |
+         | N2  | place   | city        | bonn     | 81 81 |
+         | N3  | place   | suburb      | smalltown| 80 81 |
         And the named places
          | osm | class   | type    | addr+city | addr+state | addr+suburb | geometry |
          | W1  | highway | service | bonn      | New York   | Smalltown   | :w-north |
@@ -67,8 +67,8 @@ Feature: Creation of search terms
         And the places
          | osm | class   | type        | name     | geometry |
          | N1  | place   | state       | new york | 80 80 |
-         | N1  | place   | city        | bonn     | 81 81 |
-         | N1  | place   | suburb      | smalltown| 80 81 |
+         | N2  | place   | city        | bonn     | 81 81 |
+         | N3  | place   | suburb      | smalltown| 80 81 |
         And the named places
          | osm | class   | type    | addr+is_in                | geometry |
          | W1  | highway | service | bonn, New York, Smalltown | :w-north |

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -138,6 +138,11 @@ if ($aCMDResult['index'] || $aCMDResult['all']) {
     $oSetup->index($aCMDResult['index-noanalyse']);
 }
 
+if ($aCMDResult['drop']) {
+    $bDidSomething = true;
+    $oSetup->drop($aCMDResult);
+}
+
 if ($aCMDResult['create-search-indices'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->createSearchIndices();
@@ -146,11 +151,6 @@ if ($aCMDResult['create-search-indices'] || $aCMDResult['all']) {
 if ($aCMDResult['create-country-names'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->createCountryNames($aCMDResult);
-}
-
-if ($aCMDResult['drop']) {
-    $bDidSomething = true;
-    $oSetup->drop($aCMDResult);
 }
 
 // ******************************************************


### PR DESCRIPTION
When --drop is given, we can remove all node geometry information
already after the import with osm2pgsql. Also drop all unnecessary
tables before creating the final indices.