### PR TITLE
Travis: documentation suggests we need to add postgresql-client package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - "3.6"
 addons:
   postgresql: "9.6"
+  apt:
+    packages:
+      postgresql-server-dev-9.6
+      postgresql-client-9.6
 git:
   depth: 3
 env:


### PR DESCRIPTION
https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version suggests we need to add `apt` packages before we run our installation.

There's a Travis bug report from 4 days ago where several users report similar issues (different Ubuntu version, different Postgresql version) so something could've changed on the Travis side. https://travis-ci.community/t/bionic-postgresql-10-no-longer-starts-up/6002/10