### PR TITLE
unit tests for ParameterParser::hasSetAny

### DIFF
--- a/lib/ParameterParser.php
+++ b/lib/ParameterParser.php
@@ -119,10 +119,10 @@ class ParameterParser
         return $aLangPrefOrder;
     }
 
-    public function hasSetAny($aParams)
+    public function hasSetAny($aParamNames)
     {
-        foreach ($aParams as $sParam) {
-            if ($this->getBool($sParam)) {
+        foreach ($aParamNames as $sName) {
+            if ($this->getBool($sName)) {
                 return true;
             }
         }

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -246,4 +246,22 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
                            'type' => 'type',
                           ), $oParams->getPreferredLanguages('default'));
     }
+
+    public function testHasSetAny()
+    {
+        $oParams = new ParameterParser(array(
+                                        'one' => '',
+                                        'two' => 0,
+                                        'three' => '0',
+                                        'four' => '1',
+                                        'five' => 'anystring'
+        ));
+        $this->assertFalse($oParams->hasSetAny(array()));
+        $this->assertFalse($oParams->hasSetAny(array('')));
+        $this->assertFalse($oParams->hasSetAny(array('unknown')));
+        $this->assertFalse($oParams->hasSetAny(array('one', 'two', 'three')));
+        $this->assertTrue($oParams->hasSetAny(array('one', 'four')));
+        $this->assertTrue($oParams->hasSetAny(array('four')));
+        $this->assertTrue($oParams->hasSetAny(array('five')));
+    }
 }


### PR DESCRIPTION
I renamed `$aParams` to `$aParamNames` because in the constructor we use `$aParams` for an associative array (hash, dict) while here we use it as array (list).