### PR TITLE
Make admin boundaries inherit address rank from place nodes

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -808,9 +808,7 @@ class Geocode
                         $sSQL .= 'WHERE place_id in ('.$sPlaceIds.') ';
                         $sSQL .= '  AND (';
                         $sSQL .= "         placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-                        if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) {
-                            $sSQL .= "     OR (extratags->'place') = 'city'";
-                        }
+                        $sSQL .= "         OR placex.rank_search between $this->iMinAddressRank and $this->iMaxAddressRank ";
                         if ($this->aAddressRankList) {
                             $sSQL .= '     OR placex.rank_address in ('.join(',', $this->aAddressRankList).')';
                         }

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -215,7 +215,7 @@ class PlaceLookup
                 'ST_Collect(centroid)',
                 'min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END)'
             );
-            $sSQL .= "    (extratags->'place') AS extra_place ";
+            $sSQL .= "    COALESCE(extratags->'place', extratags->'linked_place') AS extra_place ";
             $sSQL .= ' FROM placex';
             $sSQL .= " WHERE place_id in ($sPlaceIDs) ";
             $sSQL .= '   AND (';

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -248,7 +248,7 @@ class PlaceLookup
             $sSQL .= '     ref, ';
             if ($this->bExtraTags) $sSQL .= 'extratags, ';
             if ($this->bNameDetails) $sSQL .= 'name, ';
-            $sSQL .= "     extratags->'place' ";
+            $sSQL .= "     extra_place ";
 
             $aSubSelects[] = $sSQL;
         }

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -248,7 +248,7 @@ class PlaceLookup
             $sSQL .= '     ref, ';
             if ($this->bExtraTags) $sSQL .= 'extratags, ';
             if ($this->bNameDetails) $sSQL .= 'name, ';
-            $sSQL .= "     extra_place ";
+            $sSQL .= '     extra_place ';
 
             $aSubSelects[] = $sSQL;
         }

--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -660,10 +660,7 @@ class SearchDescription
             $aTerms[] = 'address_rank between 16 and 27';
         } elseif (!$this->sClass || $this->iOperator == Operator::NAME) {
             if ($iMinAddressRank > 0) {
-                $aTerms[] = 'address_rank >= '.$iMinAddressRank;
-            }
-            if ($iMaxAddressRank < 30) {
-                $aTerms[] = 'address_rank <= '.$iMaxAddressRank;
+                $aTerms[] = "((address_rank between $iMinAddressRank and $iMaxAddressRank) or (search_rank between $iMinAddressRank and $iMaxAddressRank))";
             }
         }
 

--- a/sql/functions/address_lookup.sql
+++ b/sql/functions/address_lookup.sql
@@ -202,8 +202,9 @@ BEGIN
 
   FOR location IN
     SELECT placex.place_id, osm_type, osm_id, name,
-           CASE WHEN extratags ? 'place' THEN 'place' ELSE class END as class,
-           CASE WHEN extratags ? 'place' THEN extratags->'place' ELSE type END as type,
+           CASE WHEN extratags ? 'place' or extratags ? 'linked_place'
+                THEN 'place' ELSE class END as class,
+           coalesce(extratags->'place', extratags->'linked_place', type) as type,
            admin_level, fromarea, isaddress,
            CASE WHEN rank_address = 11 THEN 5 ELSE rank_address END as rank_address,
            distance, country_code, postcode

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -841,8 +841,10 @@ BEGIN
     NEW.centroid := coalesce(location.centroid,
                              ST_Centroid(location.geometry));
 
-    -- Use the address rank of the linked place
-    NEW.rank_address := location.rank_address;
+    -- Use the address rank of the linked place, if it has one
+    IF location.rank_address between 5 and 25 THEN
+      NEW.rank_address := location.rank_address;
+    END IF;
 
     -- merge in the label name
     IF NOT location.name IS NULL THEN

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -818,7 +818,7 @@ BEGIN
   --DEBUG: RAISE WARNING 'Using full index mode for % %', NEW.osm_type, NEW.osm_id;
   SELECT * INTO location FROM find_linked_place(NEW);
   IF location.place_id is not null THEN
-      --DEBUG: RAISE WARNING 'Linked %', location;
+    --DEBUG: RAISE WARNING 'Linked %', location;
 
     -- Use this as the centre point of the geometry
     NEW.centroid := coalesce(location.centroid,
@@ -830,7 +830,7 @@ BEGIN
     END IF;
 
     -- merge in extra tags
-    NEW.extratags := hstore(location.class, location.type)
+    NEW.extratags := hstore('linked_' || location.class, location.type)
                      || coalesce(location.extratags, ''::hstore)
                      || coalesce(NEW.extratags, ''::hstore);
 

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -20,7 +20,8 @@ BEGIN
     FOR r IN 
       SELECT place_id, keywords, rank_address, rank_search, min(ST_Distance(feature, centroid)) as distance, isguess, postcode, centroid
       FROM location_area_large_-partition-
-      WHERE ST_Intersects(geometry, feature) and rank_search < maxrank
+      WHERE ST_Intersects(geometry, feature)
+        AND rank_search < maxrank AND rank_address < maxrank
       GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
       ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
         ST_Distance(feature, centroid) *

--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -127,3 +127,19 @@ Feature: Linking of places
          | N3:natural | -               |
          | N3:place   | R1              |
 
+    Scenario: Nodes with 'role' label are always linked
+        Given the places
+         | osm  | class    | type           | admin | name  | geometry |
+         | R13  | boundary | administrative | 6     | Garbo | poly-area:0.1 |
+         | N2   | place    | hamlet         | 15    | Vario | 0.006 0.00001 |
+        And the relations
+         | id | members       | tags+type |
+         | 13 | N2:label      | boundary |
+        When importing
+        Then placex contains
+         | object  | linked_place_id |
+         | N2      | R13 |
+        And placex contains
+         | object | centroid      | name+name | extratags+linked_place |
+         | R13    | 0.006 0.00001 | Garbo     | hamlet |
+

--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -143,3 +143,33 @@ Feature: Linking of places
          | object | centroid      | name+name | extratags+linked_place |
          | R13    | 0.006 0.00001 | Garbo     | hamlet |
 
+    Scenario: Boundaries with place tags are linked against places with same type
+        Given the places
+         | osm  | class    | type           | admin | name   | extra+place | geometry |
+         | R13  | boundary | administrative | 5     | Berlin | city        |poly-area:0.1 |
+        And the places
+         | osm  | class    | type           | name   | geometry |
+         | N2   | place    | city           | Berlin | 0.006 0.00001 |
+        When importing
+        Then placex contains
+         | object  | linked_place_id |
+         | N2      | R13             |
+        And placex contains
+         | object | rank_address |
+         | R13    | 16 |
+
+    Scenario: Boundaries without place tags only link against same admin level
+        Given the places
+         | osm  | class    | type           | admin | name   | geometry |
+         | R13  | boundary | administrative | 5     | Berlin |poly-area:0.1 |
+        And the places
+         | osm  | class    | type           | name   | geometry |
+         | N2   | place    | city           | Berlin | 0.006 0.00001 |
+        When importing
+        Then placex contains
+         | object  | linked_place_id |
+         | N2      | -               |
+        And placex contains
+         | object | rank_address |
+         | R13    | 10 |
+

--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -146,7 +146,7 @@ Feature: Linking of places
     Scenario: Boundaries with place tags are linked against places with same type
         Given the places
          | osm  | class    | type           | admin | name   | extra+place | geometry |
-         | R13  | boundary | administrative | 5     | Berlin | city        |poly-area:0.1 |
+         | R13  | boundary | administrative | 4     | Berlin | city        |poly-area:0.1 |
         And the places
          | osm  | class    | type           | name   | geometry |
          | N2   | place    | city           | Berlin | 0.006 0.00001 |
@@ -157,11 +157,24 @@ Feature: Linking of places
         And placex contains
          | object | rank_address |
          | R13    | 16 |
+        When searching for ""
+         | city |
+         | Berlin |
+        Then results contain
+          | ID | osm_type | osm_id |
+          |  0 | R | 13 |
+        When searching for ""
+         | state |
+         | Berlin |
+        Then results contain
+          | ID | osm_type | osm_id |
+          |  0 | R | 13 |
+
 
     Scenario: Boundaries without place tags only link against same admin level
         Given the places
          | osm  | class    | type           | admin | name   | geometry |
-         | R13  | boundary | administrative | 5     | Berlin |poly-area:0.1 |
+         | R13  | boundary | administrative | 4     | Berlin |poly-area:0.1 |
         And the places
          | osm  | class    | type           | name   | geometry |
          | N2   | place    | city           | Berlin | 0.006 0.00001 |
@@ -171,5 +184,17 @@ Feature: Linking of places
          | N2      | -               |
         And placex contains
          | object | rank_address |
-         | R13    | 10 |
+         | R13    | 8 |
+        When searching for ""
+         | state |
+         | Berlin |
+        Then results contain
+          | ID | osm_type | osm_id |
+          |  0 | R | 13 |
+        When searching for ""
+         | city |
+         | Berlin |
+        Then results contain
+          | ID | osm_type | osm_id |
+          |  0 | N | 2 |
 

--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -125,11 +125,11 @@ Feature: Updates of linked places
         When importing
         Then placex contains
          | object | extratags |
-         | R1     | 'wikidata' : '34', 'place' : 'city' |
+         | R1     | 'wikidata' : '34', 'linked_place' : 'city' |
         When updating places
          | osm | class    | type        | name    | extra+oneway | admin | geometry |
          | N3  | place    | city        | newname | yes          | 30    | 0.00001 0 |
         Then placex contains
          | object | extratags |
-         | R1     | 'wikidata' : '34', 'oneway' : 'yes', 'place' : 'city' |
+         | R1     | 'wikidata' : '34', 'oneway' : 'yes', 'linked_place' : 'city' |
 

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -297,7 +297,8 @@ def query_cmd(context, query, dups):
     """
     cmd = ['/usr/bin/env', 'php']
     cmd.append(os.path.join(context.nominatim.build_dir, 'utils', 'query.php'))
-    cmd.extend(['--search', query])
+    if query:
+        cmd.extend(['--search', query])
     # add more parameters in table form
     if context.table:
         for h in context.table.headings:


### PR DESCRIPTION
When a place node gets linked to a boundary and has an address rank defined, then the boundary inherits this address rank. This allows for such constructs as "kreisfreie Städte" where the administrative level is a county but the address classification would be whatever the place designates (i.e. city or town).

The change also changes that place tags on boundaries are taken into account for linking. This should catch those boundaries where a place tag exists but a label link is still missing. To ensure that we can recompute the correct linking, the place designation of a linked place now gets saved in 'linked_place`, so that the original place tag does not get overwritten.

Finally the algorithm for typed searches has changed slightly to not only look for places where the search rank matches the type but also the address rank. This way we will catch these reranked places.

Fixes #774.