### PR TITLE
linked centroids must always be within geometry

### DIFF
--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -198,3 +198,21 @@ Feature: Linking of places
           | ID | osm_type | osm_id |
           |  0 | N | 2 |
 
+    # github #1352
+    Scenario: Do not use linked centroid when it is outside the area
+        Given the named places
+         | osm  | class    | type           | admin | geometry |
+         | R13  | boundary | administrative | 4     | poly-area:0.01 |
+        And the named places
+         | osm  | class    | type           | geometry |
+         | N2   | place    | city           | 0.1 0.1 |
+        And the relations
+         | id | members       | tags+type |
+         | 13 | N2:label      | boundary |
+        When importing
+        Then placex contains
+         | object | linked_place_id |
+         | N2     | R13             |
+        And placex contains
+         | object | centroid |
+         | R13    | in geometry  |


### PR DESCRIPTION
When using a linked place as centroid for a boundary, check
first that it is really within the area. If it is outside,
just keep the computed centroid because a centroid outside the
area just causes havok.

Fixes #1352.