### PR TITLE
print warning if no Tiger files found

### DIFF
--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -417,8 +417,10 @@ class SetupFunctions
 
         $aFilenames = glob(CONST_Tiger_Data_Path.'/*.sql');
         info('Found '.count($aFilenames).' SQL files in path '.CONST_Tiger_Data_Path);
-        if (empty($aFilenames)) return;
-
+        if (empty($aFilenames)) {
+            warn('Tiger data import selected but no files found in path '.CONST_Tiger_Data_Path);
+            return;
+        }
         $sTemplate = file_get_contents(CONST_BasePath.'/sql/tiger_import_start.sql');
         $sTemplate = $this->replaceSqlPatterns($sTemplate);
 


### PR DESCRIPTION
https://github.com/mediagis/nominatim-docker/issues/107 mentioned it fails silently. This way the warning is repeated at the end of the installation. Let me know if a hard/fatal fail is preferred.